### PR TITLE
Fix default node and dotnet images

### DIFF
--- a/charts/miggo-operator/Chart.yaml
+++ b/charts/miggo-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: miggo-operator
-version: 0.64.6
+version: 0.64.7
 description: Miggo Operator Helm chart for Kubernetes
 type: application
 appVersion: 0.105.0

--- a/charts/miggo-operator/values.yaml
+++ b/charts/miggo-operator/values.yaml
@@ -125,13 +125,13 @@ manager:
       tag: "latest"
     nodejs:
       repository: "miggoprod/autoinstrumentation-nodejs"
-      tag: ""
+      tag: "latest"
     python:
       repository: "miggoprod/autoinstrumentation-python"
       tag: "latest"
     dotnet:
       repository: "miggoprod/autoinstrumentation-dotnet"
-      tag: ""
+      tag: "latest"
     apacheHttpd:
       repository: ""
       tag: ""


### PR DESCRIPTION
This PR add default "latest" tag to both nodejs and dotnet agents.

Without the "latest" tag, the chart won't take the specified image - see here why: https://github.com/miggo-io/miggo-helm-charts/blob/main/charts/miggo-operator/templates/deployment.yaml#L63