### PR TITLE
increase create job ttl

### DIFF
--- a/charts/miggo-operator/Chart.yaml
+++ b/charts/miggo-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: miggo-operator
-version: 0.64.7
+version: 0.64.8
 description: Miggo Operator Helm chart for Kubernetes
 type: application
 appVersion: 0.105.0

--- a/charts/miggo-operator/templates/delayed-resources/creator-job.yaml
+++ b/charts/miggo-operator/templates/delayed-resources/creator-job.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: delayed-resources-creator-job
 spec:
-  ttlSecondsAfterFinished: 1
+  ttlSecondsAfterFinished: 300
   template:
     spec:
       serviceAccountName: delayed-resources-service-account

--- a/charts/miggo-operator/templates/delayed-resources/creator-job.yaml
+++ b/charts/miggo-operator/templates/delayed-resources/creator-job.yaml
@@ -3,7 +3,6 @@ kind: Job
 metadata:
   name: delayed-resources-creator-job
 spec:
-  ttlSecondsAfterFinished: 300
   template:
     spec:
       serviceAccountName: delayed-resources-service-account


### PR DESCRIPTION
This PR keep the delayed resources creator job forever.

In doesn't harm, its good for investigation.

The main reason to keep it is to help Argo with the sync mechanism - when its gone Argo try to recreate