### PR TITLE
constant name for the instrumentation

### DIFF
--- a/charts/miggo-operator/Chart.yaml
+++ b/charts/miggo-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: miggo-operator
-version: 0.64.8
+version: 0.64.9
 description: Miggo Operator Helm chart for Kubernetes
 type: application
 appVersion: 0.105.0

--- a/charts/miggo-operator/templates/delayed-resources/configmap.yaml
+++ b/charts/miggo-operator/templates/delayed-resources/configmap.yaml
@@ -7,7 +7,7 @@ data:
     apiVersion: opentelemetry.io/v1alpha1
     kind: Instrumentation
     metadata:
-      name: {{ .Release.Name }}-instrumentation
+      name: miggo-instrumentation
     spec:
       exporter:
         endpoint: http://{{ .Release.Name }}-collector.{{ .Values.collector.collectorNameSpace | default .Release.Namespace }}:{{ .Values.collector.collectorPort }}


### PR DESCRIPTION
This PR use a fix name to the miggo-instrumentation. A name that doesn't depend on the release name which the customer may change.

The motivation of the change is to simplify the installation instructions.

This is the [counterpart PR for docs](https://github.com/miggo-io/ui-modules/pull/539)