### PR TITLE
k8s read

### DIFF
--- a/charts/miggo-operator/Chart.yaml
+++ b/charts/miggo-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: miggo-operator
-version: 0.64.10
+version: 0.64.11
 description: Miggo Operator Helm chart for Kubernetes
 type: application
 appVersion: 0.105.0

--- a/charts/miggo-operator/templates/_helpers.tpl
+++ b/charts/miggo-operator/templates/_helpers.tpl
@@ -164,3 +164,7 @@ imagePullSecrets:
 {{- define "imagePullSecretName" -}}
 {{- if (empty (index .Values.imagePullSecrets 0).name) }}miggo-regcred{{- else }}{{- (index .Values.imagePullSecrets 0).name }}{{- end }}
 {{- end -}}
+
+{{- define "collectorEndpoint" -}}
+http://{{ .Release.Name }}-collector.{{ .Values.collector.collectorNameSpace | default .Release.Namespace }}:{{ .Values.collector.collectorPort }}
+{{- end -}}

--- a/charts/miggo-operator/templates/_helpers.tpl
+++ b/charts/miggo-operator/templates/_helpers.tpl
@@ -165,6 +165,6 @@ imagePullSecrets:
 {{- if (empty (index .Values.imagePullSecrets 0).name) }}miggo-regcred{{- else }}{{- (index .Values.imagePullSecrets 0).name }}{{- end }}
 {{- end -}}
 
-{{- define "collectorEndpoint" -}}
-http://{{ .Release.Name }}-collector.{{ .Values.collector.collectorNameSpace | default .Release.Namespace }}:{{ .Values.collector.collectorPort }}
+{{- define "collectorAddress" -}}
+http://{{ .Release.Name }}-collector.{{ .Values.collector.collectorNameSpace | default .Release.Namespace }}
 {{- end -}}

--- a/charts/miggo-operator/templates/delayed-resources/configmap.yaml
+++ b/charts/miggo-operator/templates/delayed-resources/configmap.yaml
@@ -19,7 +19,7 @@ data:
       name: miggo-instrumentation
     spec:
       exporter:
-        endpoint: {{ include "collectorEndpoint" . }}
+        endpoint: {{ include "collectorAddress" . }}:{{ .Values.collector.collectorPort }}
 
       env:
         - name: OTEL_RESOURCE_ATTRIBUTES

--- a/charts/miggo-operator/templates/delayed-resources/configmap.yaml
+++ b/charts/miggo-operator/templates/delayed-resources/configmap.yaml
@@ -1,3 +1,12 @@
+{{- define "otelResourceAttributes" -}}
+  {{- if .Values.collector.customerAttr -}}
+    {{ .Values.collector.customerAttr }}
+  {{- else -}}
+    io.miggo.tenant.id={{ .Values.collector.miggoTenantId }},io.miggo.project.id={{ .Values.collector.miggoProjectId }}
+  {{- end -}}
+  {{- if .Values.collector.extraOtelAttributes }},{{ .Values.collector.extraOtelAttributes }}{{- end -}}
+{{- end -}}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,11 +19,11 @@ data:
       name: miggo-instrumentation
     spec:
       exporter:
-        endpoint: http://{{ .Release.Name }}-collector.{{ .Values.collector.collectorNameSpace | default .Release.Namespace }}:{{ .Values.collector.collectorPort }}
+        endpoint: {{ include "collectorEndpoint" . }}
 
       env:
         - name: OTEL_RESOURCE_ATTRIBUTES
-          value: {{ .Values.collector.customerAttr}}
+          value: {{ include "otelResourceAttributes" . }}
 
       sampler:
         type: parentbased_always_on

--- a/charts/miggo-operator/templates/k8s-read/deployment.yaml
+++ b/charts/miggo-operator/templates/k8s-read/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           - --cluster-name={{ .Values.k8sread.clusterName }}
           - --tenant-name={{ .Values.collector.miggoTenantId }}
           - --project-name={{ .Values.collector.miggoProjectId }}
-          - --otlp-endpoint={{ if .Values.k8sread.otlp.otlpEndpoint }}{{ .Values.k8sread.otlp.otlpEndpoint }}{{ else }}{{ include "collectorEndpoint" . }}{{ end }}
+          - --otlp-endpoint={{ if .Values.k8sread.otlp.otlpEndpoint }}{{ .Values.k8sread.otlp.otlpEndpoint }}{{ else }}{{ include "collectorAddress" . }}:{{ .Values.k8sread.otlp.otlpPort }}{{ end }}
           {{- if .Values.k8sread.otlp.httpAuthHeader }}--otlp-auth-header={{- .Values.k8sread.otlp.httpAuthHeader }}{{- end}}
           - --tls-skip-verify={{ .Values.k8sread.otlp.tlsSkipVerify }}
           - --stdout={{ .Values.k8sread.stdout }}

--- a/charts/miggo-operator/templates/k8s-read/deployment.yaml
+++ b/charts/miggo-operator/templates/k8s-read/deployment.yaml
@@ -1,0 +1,72 @@
+{{ if .Values.k8sread.enabled  }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  {{- if .Values.manager.deploymentAnnotations }}
+  {{- with .Values.k8sread.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  name: k8s-read
+  labels:
+    app: k8s-read
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: k8s-read
+  template:
+    metadata:
+      {{- if .Values.manager.podAnnotations }}
+      {{- with .Values.k8sread.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+      {{- end }}
+      labels:
+        app: k8s-read
+    spec:
+      serviceAccountName: k8s-read-sa
+      containers:
+      - name: k8s-read
+        image: "{{ .Values.k8sread.image.repository }}:{{ .Values.k8sread.image.tag }}"
+        imagePullPolicy: {{ .Values.k8sread.imagePullPolicy }}
+        args:
+          - --cluster-name={{ .Values.k8sread.clusterName }}
+          - --tenant-name={{ .Values.collector.miggoTenantId }}
+          - --project-name={{ .Values.collector.miggoProjectId }}
+          - --otlp-endpoint={{ if .Values.k8sread.otlp.otlpEndpoint }}{{ .Values.k8sread.otlp.otlpEndpoint }}{{ else }}{{ include "collectorEndpoint" . }}{{ end }}
+          {{- if .Values.k8sread.otlp.httpAuthHeader }}--otlp-auth-header={{- .Values.k8sread.otlp.httpAuthHeader }}{{- end}}
+          - --tls-skip-verify={{ .Values.k8sread.otlp.tlsSkipVerify }}
+          - --stdout={{ .Values.k8sread.stdout }}
+          - --port={{ .Values.k8sread.healthcheck.port }}
+        ports:
+        - containerPort: {{ .Values.k8sread.healthcheck.port }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.k8sread.healthcheck.port }}
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.k8sread.healthcheck.port }}
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        resources: {{ toYaml .Values.k8sread.resources | nindent 12 }}
+      {{- with .Values.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 10
+{{ end }}

--- a/charts/miggo-operator/templates/k8s-read/role-biniding.yaml
+++ b/charts/miggo-operator/templates/k8s-read/role-biniding.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.k8sread.enabled  }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8s-read-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: k8s-read-sa
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: k8s-read-role
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/charts/miggo-operator/templates/k8s-read/role.yaml
+++ b/charts/miggo-operator/templates/k8s-read/role.yaml
@@ -1,0 +1,30 @@
+{{ if .Values.k8sread.enabled  }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8s-read-role
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments", "statefulsets"]
+  verbs: ["get", "list", "watch"]
+
+- apiGroups: [""]
+  resources: ["services", "pods"]
+  verbs: ["get", "list", "watch"]
+
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses", "ingressclasses"]
+  verbs: ["get", "list", "watch"]
+
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources: ["gateways", "httproutes"]
+  verbs: ["get", "list", "watch"]
+
+- apiGroups: ["apps"]
+  resources: ["daemonsets"]
+  verbs: ["get", "list", "watch"]
+
+- apiGroups: ["batch"]
+  resources: ["cronjobs"]
+  verbs: ["get", "list", "watch"]
+{{ end }}

--- a/charts/miggo-operator/templates/k8s-read/service-account.yaml
+++ b/charts/miggo-operator/templates/k8s-read/service-account.yaml
@@ -1,0 +1,10 @@
+{{ if and .Values.k8sread.enabled  .Values.k8sread.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8s-read-sa
+  {{- with .Values.k8sread.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{ end }}

--- a/charts/miggo-operator/values.schema.json
+++ b/charts/miggo-operator/values.schema.json
@@ -30,6 +30,8 @@
     "properties": {
         "collector":{
         },
+        "k8sread":{
+        },
         "updater":{
         },
         "secretsSyncer":{

--- a/charts/miggo-operator/values.yaml
+++ b/charts/miggo-operator/values.yaml
@@ -121,6 +121,7 @@ k8sread:
     tag: latest
   otlp:
     otlpEndpoint: ""
+    otlpPort: 4317 # used only if otlpEndpoint is missing
     httpAuthHeader: ""
     tlsSkipVerify: true
   healthcheck:

--- a/charts/miggo-operator/values.yaml
+++ b/charts/miggo-operator/values.yaml
@@ -49,9 +49,14 @@ pdb:
 # Collector configuration
 # 
 collector:
+  
   # Tenant and Project id, format:
   # io.miggo.tenant.id=<id>,io.miggo.project.id=<id>
-  customerAttr: ""
+  customerAttr: ""  # deprecated - use miggoTenantId, miggoProjectId, extraOtelAttributes instead
+  
+  miggoTenantId: ""
+  miggoProjectId: ""
+  extraOtelAttributes: ""
 
   # If one collector deployed for diff namesapces, specify false, and collector namespace
   deployCollector: true
@@ -105,6 +110,33 @@ updater:
     accessKeyId: ""
     secretAccessKey: ""
     region: ""
+
+k8sread:
+  enabled: false
+  stdout: false
+  clusterName: "kubernetes-cluster"
+  imagePullPolicy: Always # Keep always, for other options contact us (miggo.io)
+  image:
+    repository: miggoprod/k8s-read
+    tag: latest
+  otlp:
+    otlpEndpoint: ""
+    httpAuthHeader: ""
+    tlsSkipVerify: true
+  healthcheck:
+    port: 6666
+  deploymentAnnotations: {}
+  podAnnotations: {}
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 64Mi
+  serviceAccount:
+    create: true
+    annotations: {}
 
 ## Provide OpenTelemetry Operator manager container image and resources.
 ##


### PR DESCRIPTION
This PR introduces the `k8s-read` component to the miggo Helm chart. By default, the k8s-read component is disabled to avoid unintended impact on current deployments.

While the addition of the new Kubernetes components is non-disruptive to existing features, there are few important things to consider before merge.

1. **Collector Endpoint Calculation:**
The logic for calculating the collector endpoint has been moved to a dedicated function. This refactor allows the endpoint calculation to be shared between both the instrumentation component and the new `k8s-read` component.

2. **Deprecation of collector.customerAttr:**
The `collector.customerAttr` property is now deprecated and replaced with two new properties: `collector.miggoTenantId` and `collector.miggoProjectId`. These new properties simplify passing data to the `k8s-read` component without the need for complex parsing.

- Backward Compatibility: The deprecated property remains functional to ensure compatibility with existing installations.
- New Attribute Support: A new `collector.extraOtelAttributes` property has also been added, allowing users to pass additional OpenTelemetry attributes regardless of whether they use the old or new properties.

3. **Protocol Changes for `k8s-read`:**
The k8s-read component sends data using the gRPC protocol, while the chart traditionally uses HTTP by default. To prevent breaking changes, there are two properties to configure the port:
- `collector.collectorPort`: This existing property continues to be used by the instrumentation CRD.
- `k8sread.otlp.otlpPort`: This new property specifies the port used by the `k8s-read` component for gRPC communication.

4. **Cluster Name:**
The new `k8s-read` needs/want a cluster name, currently we don't have a smart way to get it. A new property `k8sread.clusterName` introduced with default value of `kubernetes-cluster`
