### PR TITLE
replace deprecated logging with debug exporter

### DIFF
--- a/charts/miggo-operator/templates/delayed-resources/configmap.yaml
+++ b/charts/miggo-operator/templates/delayed-resources/configmap.yaml
@@ -61,13 +61,13 @@ data:
           batch: {}
 
         exporters:
-          logging:
-            loglevel: debug
+          debug:
+            verbosity: basic
 
         service:
           pipelines:
             traces:
               receivers: [otlp]
-              exporters: [logging]
+              exporters: [debug]
               processors: [batch]
 {{ end }}


### PR DESCRIPTION
Remove the deprecated `logging` exporter, use the `debug` exporter instead as says by the [docs](https://github.com/open-telemetry/opentelemetry-collector/pull/11037) 

See [this PR](https://github.com/miggo-io/infra-agent/pull/47) for context