### PR TITLE
let bump version to update umbrella charts

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -55,6 +55,10 @@ jobs:
             for umbrella_chart in ${UMBRELLA_CHARTS[@]}; do
               local chart_file="charts/$umbrella_chart/Chart.yaml"
               
+              CURRENT_VERSION=$(yq eval '.version' "$chart_file")
+              NEW_VERSION=$(bump_version "$CURRENT_VERSION")
+              
+              yq eval ".version = \"$NEW_VERSION\"" -i "$chart_file"
               yq e "(.dependencies[] | select(.name == \"$chart\").version) = \"$new_version\"" -i $chart_file
             done
           }

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -38,12 +38,25 @@ jobs:
         run: |
           set -x 
           
+          UMBRELLA_CHARTS=(k8s-integration)
+
           # Function to bump patch version
           bump_version() {
             local version=$1
             local major minor patch
             IFS='.' read -r major minor patch <<< "$version"
             echo "$major.$minor.$((patch + 1))"
+          }
+          
+          update_umbrella_charts() {
+            local chart=$1
+            local new_version=$2
+            
+            for umbrella_chart in ${UMBRELLA_CHARTS[@]}; do
+              local chart_file="charts/$umbrella_chart/Chart.yaml"
+              
+              yq e "(.dependencies[] | select(.name == \"$chart\").version) = \"$new_version\"" -i $chart_file
+            done
           }
 
           BASE_COMMIT_SHA=${{ github.event.pull_request.base.sha }}
@@ -87,6 +100,7 @@ jobs:
                     NEW_VERSION=$(bump_version "$CURRENT_VERSION")
                     echo "Bumping to new version: $NEW_VERSION"
                     yq eval ".version = \"$NEW_VERSION\"" -i "$CHART_YAML"
+                    update_umbrella_charts $CHART_NAME $NEW_VERSION
                     echo "Bumped $CHART_NAME version from $CURRENT_VERSION to $NEW_VERSION"
                     
                     # Set output for next step


### PR DESCRIPTION
This PR enhances the bump-version workflow to propagate version updates through dependent charts. 

When a chart like k8s-read gets updated, the workflow automatically updates references to it in dependent charts (like k8s-integration).