### PR TITLE
Fix k8s integrations

### DIFF
--- a/charts/k8s-integration/Chart.yaml
+++ b/charts/k8s-integration/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 name: k8s-integration
 description: A Helm chart for miggo's k8s-integration
 type: application
-version: 0.0.2
+version: 0.0.4
 appVersion: "0.0.1"
 dependencies:
   - name: k8s-read
     repository: https://miggo-io.github.io/miggo-helm-charts
-    version: 0.0.1
+    version: 0.0.6
     condition: k8s-read.enabled
   - name: static-sbom
     repository: https://miggo-io.github.io/miggo-helm-charts
-    version: 0.0.3
+    version: 0.0.9
     condition: static-sbom.enabled

--- a/charts/k8s-read/Chart.yaml
+++ b/charts/k8s-read/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: k8s-read
 description: A Helm chart for miggo's k8s-read
 type: application
-version: 0.0.5
+version: 0.0.6
 appVersion: "0.0.1"

--- a/charts/k8s-read/templates/_helpers.tpl
+++ b/charts/k8s-read/templates/_helpers.tpl
@@ -64,7 +64,7 @@ Create the name of the service account to use
 {{- define "imagePullSecrets" -}}
 {{- $emptyImagePullSecrets := list (dict "name" "") }}
 {{- $global := .Values.global | default dict }}
-{{- $globalImagePullSecrets := dig "global" "imagePullSecrets" $emptyImagePullSecrets $global }}
+{{- $globalImagePullSecrets := dig "imagePullSecrets" $emptyImagePullSecrets $global }}
 {{- if (not (empty (index .Values.imagePullSecrets 0).name)) }}
 imagePullSecrets:
   {{- toYaml .Values.imagePullSecrets | nindent 2 }}

--- a/charts/k8s-read/templates/deployment.yaml
+++ b/charts/k8s-read/templates/deployment.yaml
@@ -33,16 +33,16 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             {{- $global := .Values.global | default dict }}
-            {{- $globalClusterName := dig "global" "miggo" "clusterName" "" $global }}
-            {{- $globalTenantId := dig "global" "miggo" "projectId" "" $global }}
-            {{- $globalProjectId := dig "global" "miggo" "tenantId" "" $global }}
-            {{- $globalOtlpEndpoint := dig "global" "output" "otlp" "otlpEndpoint" "" $global }}
-            {{- $globalTlsSkipVerify := dig "global" "output" "otlp" "tlsSkipVerify" "" $global }}
-            {{- $globalStdout := dig "global" "output" "stdout" "" $global }}
-            {{- $globalHealthPort := dig "global" "healthcheck" "port" "" $global }}
-            {{- $globalMetricOtlpEndpoint := dig "global" "output" "otlp" "otlpEndpoint" "" $global }}
-            {{- $globalMetricTlsSkipVerify := dig "global" "output" "otlp" "tlsSkipVerify" "" $global }}
-            {{- $globalMetricInterval := dig "global" "config" "metrics" "interval" "" $global }}
+            {{- $globalClusterName := dig "miggo" "clusterName" "" $global }}
+            {{- $globalTenantId := dig "miggo" "projectId" "" $global }}
+            {{- $globalProjectId := dig "miggo" "tenantId" "" $global }}
+            {{- $globalOtlpEndpoint := dig "output" "otlp" "otlpEndpoint" "" $global }}
+            {{- $globalTlsSkipVerify := dig "output" "otlp" "tlsSkipVerify" "" $global }}
+            {{- $globalStdout := dig "output" "stdout" "" $global }}
+            {{- $globalHealthPort := dig "healthcheck" "port" "" $global }}
+            {{- $globalMetricOtlpEndpoint := dig "output" "otlp" "otlpEndpoint" "" $global }}
+            {{- $globalMetricTlsSkipVerify := dig "output" "otlp" "tlsSkipVerify" "" $global }}
+            {{- $globalMetricInterval := dig "config" "metrics" "interval" "" $global }}
             - --cluster-name={{ coalesce .Values.miggo.clusterName $globalClusterName }}
             - --tenant-name={{ coalesce .Values.miggo.tenantId $globalTenantId }}  
             - --project-name={{ coalesce .Values.miggo.projectId $globalProjectId }}

--- a/charts/k8s-read/templates/image-secrets.yaml
+++ b/charts/k8s-read/templates/image-secrets.yaml
@@ -1,4 +1,7 @@
-{{- if (empty (index .Values.imagePullSecrets 0).name) }}
+{{- $global := .Values.global | default dict }}
+{{- $globalImageCredentialsUsername := dig "imageCredentials" "username" "" $global }}
+{{- $username := coalesce .Values.imageCredentials.username $globalImageCredentialsUsername }}
+{{- if and (empty (index .Values.imagePullSecrets 0).name) (not (empty $username)) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,11 +9,10 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   {{- $global := .Values.global | default dict }}
-  {{- $globalImageCredentialsRegistry := dig "global" "imageCredentials" "registry" "" $global }}
-  {{- $globalImageCredentialsUsername := dig "global" "imageCredentials" "username" "" $global }}
-  {{- $globalImageCredentialsPassword := dig "global" "imageCredentials" "password" "" $global }}
+  {{- $globalImageCredentialsRegistry := dig "imageCredentials" "registry" "" $global }}
+  {{- $globalImageCredentialsUsername := dig "imageCredentials" "username" "" $global }}
+  {{- $globalImageCredentialsPassword := dig "imageCredentials" "password" "" $global }}
   {{- $imageCredentialsRegistry := coalesce .Values.imageCredentials.registry $globalImageCredentialsRegistry }}
-  {{- $imageCredentialsUsername := coalesce .Values.imageCredentials.username $globalImageCredentialsUsername }}
   {{- $imageCredentialsPassword := coalesce .Values.imageCredentials.password $globalImageCredentialsPassword }}
-  .dockerconfigjson: {{ printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\"}}}" $imageCredentialsRegistry $imageCredentialsUsername $imageCredentialsPassword | b64enc | quote }}
+  .dockerconfigjson: {{ printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\"}}}" $imageCredentialsRegistry $username $imageCredentialsPassword | b64enc | quote }}
 {{- end }}

--- a/charts/k8s-read/templates/oltp-secret.yaml
+++ b/charts/k8s-read/templates/oltp-secret.yaml
@@ -1,11 +1,14 @@
-{{- if empty .Values.output.otlp.existingSecret }}
+{{- $global := .Values.global | default dict }}
+{{- $globalOtlpHttpAuthHeader := dig "output" "otlp" "httpAuthHeader" "" $global }}
+{{- $authHeader := coalesce .Values.output.otlp.httpAuthHeader $globalOtlpHttpAuthHeader }}
+{{- if and (empty .Values.output.otlp.existingSecret) (not (empty $authHeader)) }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: k8s-read-otlp-secret
 type: Opaque
 data:
-  K8S_READ_OTLP_AUTH_HEADER: {{ .Values.output.otlp.httpAuthHeader | b64enc | quote }}
-  K8S_READ_METRIC_OTLP_AUTH_HEADER: {{ .Values.output.otlp.httpAuthHeader | b64enc | quote }}
+  K8S_READ_OTLP_AUTH_HEADER: {{ $authHeader | b64enc | quote }}
+  K8S_READ_METRIC_OTLP_AUTH_HEADER: {{ $authHeader | b64enc | quote }}
 {{- end }}
 ---

--- a/charts/static-sbom/Chart.yaml
+++ b/charts/static-sbom/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: static-sbom
 description: A Helm chart for miggo's static-sbom
 type: application
-version: 0.0.8
+version: 0.0.9
 appVersion: "0.0.1"

--- a/charts/static-sbom/templates/_helpers.tpl
+++ b/charts/static-sbom/templates/_helpers.tpl
@@ -64,7 +64,7 @@ Create the name of the service account to use
 {{- define "imagePullSecrets" -}}
 {{- $emptyImagePullSecrets := list (dict "name" "") }}
 {{- $global := .Values.global | default dict }}
-{{- $globalImagePullSecrets := dig "global" "imagePullSecrets" $emptyImagePullSecrets $global }}
+{{- $globalImagePullSecrets := dig "imagePullSecrets" $emptyImagePullSecrets $global }}
 {{- if (not (empty (index .Values.imagePullSecrets 0).name)) }}
 imagePullSecrets:
   {{- toYaml .Values.imagePullSecrets | nindent 2 }}

--- a/charts/static-sbom/templates/deployment.yaml
+++ b/charts/static-sbom/templates/deployment.yaml
@@ -33,16 +33,16 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             {{- $global := .Values.global | default dict }}
-            {{- $globalClusterName := dig "global" "miggo" "clusterName" "" $global }}
-            {{- $globalTenantId := dig "global" "miggo" "projectId" "" $global }}
-            {{- $globalProjectId := dig "global" "miggo" "tenantId" "" $global }}
-            {{- $globalOtlpEndpoint := dig "global" "output" "otlp" "otlpEndpoint" "" $global }}
-            {{- $globalTlsSkipVerify := dig "global" "output" "otlp" "tlsSkipVerify" "" $global }}
-            {{- $globalStdout := dig "global" "output" "stdout" "" $global }}
-            {{- $globalHealthPort := dig "global" "healthcheck" "port" "" $global }}
-            {{- $globalMetricOtlpEndpoint := dig "global" "output" "otlp" "otlpEndpoint" "" $global }}
-            {{- $globalMetricTlsSkipVerify := dig "global" "output" "otlp" "tlsSkipVerify" "" $global }}
-            {{- $globalMetricInterval := dig "global" "config" "metrics" "interval" "" $global }}
+            {{- $globalClusterName := dig "miggo" "clusterName" "" $global }}
+            {{- $globalTenantId := dig "miggo" "projectId" "" $global }}
+            {{- $globalProjectId := dig "miggo" "tenantId" "" $global }}
+            {{- $globalOtlpEndpoint := dig "output" "otlp" "otlpEndpoint" "" $global }}
+            {{- $globalTlsSkipVerify := dig "output" "otlp" "tlsSkipVerify" "" $global }}
+            {{- $globalStdout := dig "output" "stdout" "" $global }}
+            {{- $globalHealthPort := dig "healthcheck" "port" "" $global }}
+            {{- $globalMetricOtlpEndpoint := dig "output" "otlp" "otlpEndpoint" "" $global }}
+            {{- $globalMetricTlsSkipVerify := dig "output" "otlp" "tlsSkipVerify" "" $global }}
+            {{- $globalMetricInterval := dig "config" "metrics" "interval" "" $global }}
             - --cluster-name={{ coalesce .Values.miggo.clusterName $globalClusterName }}
             - --tenant-name={{ coalesce .Values.miggo.tenantId $globalTenantId }}  
             - --project-name={{ coalesce .Values.miggo.projectId $globalProjectId }}

--- a/charts/static-sbom/templates/image-secrets.yaml
+++ b/charts/static-sbom/templates/image-secrets.yaml
@@ -1,4 +1,7 @@
-{{- if (empty (index .Values.imagePullSecrets 0).name) }}
+{{- $global := .Values.global | default dict }}
+{{- $globalImageCredentialsUsername := dig "imageCredentials" "username" "" $global }}
+{{- $username := coalesce .Values.imageCredentials.username $globalImageCredentialsUsername }}
+{{- if and (empty (index .Values.imagePullSecrets 0).name) (not (empty $username)) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,11 +9,10 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   {{- $global := .Values.global | default dict }}
-  {{- $globalImageCredentialsRegistry := dig "global" "imageCredentials" "registry" "" $global }}
-  {{- $globalImageCredentialsUsername := dig "global" "imageCredentials" "username" "" $global }}
-  {{- $globalImageCredentialsPassword := dig "global" "imageCredentials" "password" "" $global }}
+  {{- $globalImageCredentialsRegistry := dig "imageCredentials" "registry" "" $global }}
+  {{- $globalImageCredentialsUsername := dig "imageCredentials" "username" "" $global }}
+  {{- $globalImageCredentialsPassword := dig "imageCredentials" "password" "" $global }}
   {{- $imageCredentialsRegistry := coalesce .Values.imageCredentials.registry $globalImageCredentialsRegistry }}
-  {{- $imageCredentialsUsername := coalesce .Values.imageCredentials.username $globalImageCredentialsUsername }}
   {{- $imageCredentialsPassword := coalesce .Values.imageCredentials.password $globalImageCredentialsPassword }}
-  .dockerconfigjson: {{ printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\"}}}" $imageCredentialsRegistry $imageCredentialsUsername $imageCredentialsPassword | b64enc | quote }}
+  .dockerconfigjson: {{ printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\"}}}" $imageCredentialsRegistry $username $imageCredentialsPassword | b64enc | quote }}
 {{- end }}

--- a/charts/static-sbom/templates/oltp-secret.yaml
+++ b/charts/static-sbom/templates/oltp-secret.yaml
@@ -1,11 +1,14 @@
-{{- if empty .Values.output.otlp.existingSecret }}
+{{- $global := .Values.global | default dict }}
+{{- $globalOtlpHttpAuthHeader := dig "output" "otlp" "httpAuthHeader" "" $global }}
+{{- $authHeader := coalesce .Values.output.otlp.httpAuthHeader $globalOtlpHttpAuthHeader }}
+{{- if and (empty .Values.output.otlp.existingSecret) (not (empty $authHeader)) }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: static-sbom-otlp-secret
 type: Opaque
 data:
-  STATIC_SBOM_OTLP_AUTH_HEADER: {{ .Values.output.otlp.httpAuthHeader | b64enc | quote }}
-  STATIC_SBOM_METRIC_OTLP_AUTH_HEADER: {{ .Values.output.otlp.httpAuthHeader | b64enc | quote }}
+  STATIC_SBOM_OTLP_AUTH_HEADER: {{ $authHeader | b64enc | quote }}
+  STATIC_SBOM_METRIC_OTLP_AUTH_HEADER: {{ $authHeader | b64enc | quote }}
 {{- end }}
 ---


### PR DESCRIPTION
This PR do 3 things to make k8s-integration chart ready for customers:

1. Fix a mistake that access `.global` twice in various places
2. Bump versions of the k8s-integration and its dependencies (See [this PR](https://github.com/miggo-io/miggo-helm-charts/pull/48) which automate this task)
3. Do not create empty secrets if a customer want to use its own secrets - not only related to k8s-integrations but a general fix