### PR TITLE
add labels to deploy + tpl support + flush cache interval for static …

### DIFF
--- a/charts/k8s-integration/Chart.yaml
+++ b/charts/k8s-integration/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 name: k8s-integration
 description: A Helm chart for miggo's k8s-integration
 type: application
-version: 0.0.4
+version: 0.0.6
 appVersion: "0.0.1"
 dependencies:
   - name: k8s-read
     repository: https://miggo-io.github.io/miggo-helm-charts
-    version: 0.0.6
+    version: 0.0.7
     condition: k8s-read.enabled
   - name: static-sbom
     repository: https://miggo-io.github.io/miggo-helm-charts
-    version: 0.0.9
+    version: 0.0.10
     condition: static-sbom.enabled

--- a/charts/k8s-read/Chart.yaml
+++ b/charts/k8s-read/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: k8s-read
 description: A Helm chart for miggo's k8s-read
 type: application
-version: 0.0.6
+version: 0.0.7
 appVersion: "0.0.1"

--- a/charts/k8s-read/templates/deployment.yaml
+++ b/charts/k8s-read/templates/deployment.yaml
@@ -4,6 +4,13 @@ metadata:
   name: {{ include "k8s-read.fullname" . }}
   labels:
     {{- include "k8s-read.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:
@@ -13,12 +20,12 @@ spec:
     metadata:
       {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       labels:
         {{- include "k8s-read.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
     spec:
       {{- include "imagePullSecrets" . | nindent 6 }}
@@ -54,6 +61,9 @@ spec:
             - --metric-tls-skip-verify={{ default .Values.output.otlp.tlsSkipVerify $globalMetricTlsSkipVerify }}
             - --metric-interval={{ coalesce .Values.config.metrics.interval $globalMetricInterval }}
             - --interval={{ .Values.config.interval }}
+            {{ if .Values.config.disableCompression }}
+            - --disable-compression
+            {{ end }}
           envFrom:
           {{- if .Values.output.otlp.existingSecret }}
           - secretRef:

--- a/charts/k8s-read/values.yaml
+++ b/charts/k8s-read/values.yaml
@@ -22,6 +22,7 @@ miggo:
 
 config:
   interval: 6h
+  disableCompression: false
   metrics:
     interval: 60s
 
@@ -47,6 +48,9 @@ serviceAccount:
   automount: true
   annotations: {}
   name: ""
+
+labels: {}
+annotations: {}
 
 podAnnotations: {}
 podLabels: {}

--- a/charts/static-sbom/Chart.yaml
+++ b/charts/static-sbom/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: static-sbom
 description: A Helm chart for miggo's static-sbom
 type: application
-version: 0.0.9
+version: 0.0.10
 appVersion: "0.0.1"

--- a/charts/static-sbom/templates/deployment.yaml
+++ b/charts/static-sbom/templates/deployment.yaml
@@ -4,6 +4,13 @@ metadata:
   name: {{ include "static-sbom.fullname" . }}
   labels:
     {{- include "static-sbom.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:
@@ -13,12 +20,12 @@ spec:
     metadata:
       {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       labels:
         {{- include "static-sbom.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
     spec:
       {{- include "imagePullSecrets" . | nindent 6 }}
@@ -57,6 +64,7 @@ spec:
             {{ if .Values.config.disableCompression }}
             - --disable-compression
             {{ end }}
+            - --cache-flush-interval={{ .Values.config.cache.flushInterval }}
             - --cache-size={{ .Values.config.cache.maxEntries }}
             {{ if .Values.config.cache.configMap.enabled }}
             - --cache-cm-name={{ include "static-sbom.configMapCacheName" . }}

--- a/charts/static-sbom/values.yaml
+++ b/charts/static-sbom/values.yaml
@@ -23,9 +23,11 @@ miggo:
 config:
   queueSize: 10000
   disableCompression: false
+  flushInterval: 168h
   metrics:
     interval: 60s
   cache:
+    
     maxEntries: 10000
     configMap:
       enabled: true
@@ -53,6 +55,9 @@ serviceAccount:
   automount: true
   annotations: {}
   name: ""
+
+labels: {}
+annotations: {}
 
 podAnnotations: {}
 podLabels: {}

--- a/charts/static-sbom/values.yaml
+++ b/charts/static-sbom/values.yaml
@@ -23,7 +23,7 @@ miggo:
 config:
   queueSize: 10000
   disableCompression: false
-  flushInterval: 168h
+  flushInterval: 7d # put 0 to disable
   metrics:
     interval: 60s
   cache:


### PR DESCRIPTION
Changes included:
1. Allow the user to specify labels for deployment
2. Allow the user to disable payload compression for k8s-read
3. Allow the user to use templates withing annotations and labels
4. Allow the user to configure cache flush interval (default to 7 days)