### PR TITLE
secrets are optional

### DIFF
--- a/charts/k8s-read/templates/_helpers.tpl
+++ b/charts/k8s-read/templates/_helpers.tpl
@@ -65,13 +65,15 @@ Create the name of the service account to use
 {{- $emptyImagePullSecrets := list (dict "name" "") }}
 {{- $global := .Values.global | default dict }}
 {{- $globalImagePullSecrets := dig "imagePullSecrets" $emptyImagePullSecrets $global }}
+{{- $globalImageCredentialsUsername := dig "imageCredentials" "username" "" $global }}
+{{- $username := coalesce .Values.imageCredentials.username $globalImageCredentialsUsername }}
 {{- if (not (empty (index .Values.imagePullSecrets 0).name)) }}
 imagePullSecrets:
   {{- toYaml .Values.imagePullSecrets | nindent 2 }}
 {{- else if (not (empty (index $globalImagePullSecrets 0).name)) }}
 imagePullSecrets:
   {{- toYaml .Values.global.imagePullSecrets | nindent 2 }}
-{{- else }}
+{{- else if (not (empty $username)) }}
 imagePullSecrets:
   - name: k8s-read-miggo-regcred
 {{- end }}
@@ -79,4 +81,13 @@ imagePullSecrets:
 
 {{- define "k8s-read.configMapCacheName" -}}
 {{- default (printf "%s-cache" (include "k8s-read.fullname" .)) .Values.config.cache.configMap.name }}
+{{- end }}
+
+{{- define "common.otlp.authHeader" -}}
+{{- $global := .Values.global | default dict }}
+{{- $globalOtlpHttpAuthHeader := dig "output" "otlp" "httpAuthHeader" "" $global }}
+{{- $authHeader := coalesce .Values.output.otlp.httpAuthHeader $globalOtlpHttpAuthHeader "" }}
+{{- if $authHeader }}
+{{- $authHeader -}}
+{{- end }}
 {{- end }}

--- a/charts/k8s-read/templates/deployment.yaml
+++ b/charts/k8s-read/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
           {{- if .Values.output.otlp.existingSecret }}
           - secretRef:
               name: {{ .Values.output.otlp.existingSecret }}
-          {{- else }}
+          {{- else if (not (empty (include "common.otlp.authHeader" .))) }}
           - secretRef:
               name: k8s-read-otlp-secret
           {{- end }}

--- a/charts/k8s-read/templates/oltp-secret.yaml
+++ b/charts/k8s-read/templates/oltp-secret.yaml
@@ -1,14 +1,11 @@
-{{- $global := .Values.global | default dict }}
-{{- $globalOtlpHttpAuthHeader := dig "output" "otlp" "httpAuthHeader" "" $global }}
-{{- $authHeader := coalesce .Values.output.otlp.httpAuthHeader $globalOtlpHttpAuthHeader }}
-{{- if and (empty .Values.output.otlp.existingSecret) (not (empty $authHeader)) }}
+{{- if and (empty .Values.output.otlp.existingSecret) (not (empty (include "common.otlp.authHeader" .))) }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: k8s-read-otlp-secret
 type: Opaque
 data:
-  K8S_READ_OTLP_AUTH_HEADER: {{ $authHeader | b64enc | quote }}
-  K8S_READ_METRIC_OTLP_AUTH_HEADER: {{ $authHeader | b64enc | quote }}
+  K8S_READ_OTLP_AUTH_HEADER: {{ (include "common.otlp.authHeader" .) | b64enc | quote }}
+  K8S_READ_METRIC_OTLP_AUTH_HEADER: {{ (include "common.otlp.authHeader" .) | b64enc | quote }}
 {{- end }}
 ---

--- a/charts/static-sbom/templates/_helpers.tpl
+++ b/charts/static-sbom/templates/_helpers.tpl
@@ -65,13 +65,15 @@ Create the name of the service account to use
 {{- $emptyImagePullSecrets := list (dict "name" "") }}
 {{- $global := .Values.global | default dict }}
 {{- $globalImagePullSecrets := dig "imagePullSecrets" $emptyImagePullSecrets $global }}
+{{- $globalImageCredentialsUsername := dig "imageCredentials" "username" "" $global }}
+{{- $username := coalesce .Values.imageCredentials.username $globalImageCredentialsUsername }}
 {{- if (not (empty (index .Values.imagePullSecrets 0).name)) }}
 imagePullSecrets:
   {{- toYaml .Values.imagePullSecrets | nindent 2 }}
 {{- else if (not (empty (index $globalImagePullSecrets 0).name)) }}
 imagePullSecrets:
   {{- toYaml .Values.global.imagePullSecrets | nindent 2 }}
-{{- else }}
+{{- else if (not (empty $username)) }}
 imagePullSecrets:
   - name: static-sbom-miggo-regcred
 {{- end }}
@@ -79,4 +81,13 @@ imagePullSecrets:
 
 {{- define "static-sbom.configMapCacheName" -}}
 {{- default (printf "%s-cache" (include "static-sbom.fullname" .)) .Values.config.cache.configMap.name }}
+{{- end }}
+
+{{- define "common.otlp.authHeader" -}}
+{{- $global := .Values.global | default dict }}
+{{- $globalOtlpHttpAuthHeader := dig "output" "otlp" "httpAuthHeader" "" $global }}
+{{- $authHeader := coalesce .Values.output.otlp.httpAuthHeader $globalOtlpHttpAuthHeader "" }}
+{{- if $authHeader }}
+{{- $authHeader -}}
+{{- end }}
 {{- end }}

--- a/charts/static-sbom/templates/deployment.yaml
+++ b/charts/static-sbom/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
           {{- if .Values.output.otlp.existingSecret }}
           - secretRef:
               name: {{ .Values.output.otlp.existingSecret }}
-          {{- else }}
+          {{- else if (not (empty (include "common.otlp.authHeader" .))) }}
           - secretRef:
               name: static-sbom-otlp-secret
           {{- end }}

--- a/charts/static-sbom/templates/oltp-secret.yaml
+++ b/charts/static-sbom/templates/oltp-secret.yaml
@@ -1,14 +1,11 @@
-{{- $global := .Values.global | default dict }}
-{{- $globalOtlpHttpAuthHeader := dig "output" "otlp" "httpAuthHeader" "" $global }}
-{{- $authHeader := coalesce .Values.output.otlp.httpAuthHeader $globalOtlpHttpAuthHeader }}
-{{- if and (empty .Values.output.otlp.existingSecret) (not (empty $authHeader)) }}
+{{- if and (empty .Values.output.otlp.existingSecret) (not (empty (include "common.otlp.authHeader" .))) }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: static-sbom-otlp-secret
 type: Opaque
 data:
-  STATIC_SBOM_OTLP_AUTH_HEADER: {{ $authHeader | b64enc | quote }}
-  STATIC_SBOM_METRIC_OTLP_AUTH_HEADER: {{ $authHeader | b64enc | quote }}
+  STATIC_SBOM_OTLP_AUTH_HEADER: {{ (include "common.otlp.authHeader" .) | b64enc | quote }}
+  STATIC_SBOM_METRIC_OTLP_AUTH_HEADER: {{ (include "common.otlp.authHeader" .) | b64enc | quote }}
 {{- end }}
 ---


### PR DESCRIPTION
Solving the problem for customers who manage their own secrets in their own way:

See the following for example:
```yaml
image:
  registry: customer-own-registory/k8s-read

miggo:
  tenantId: "0654a211-37ca-7a9f-8000-f111e59b1c7f" # dev-test
  projectId: "f8fe49bb-b2eb-4a6e-9735-cee5ee472641"
  name: "test"

output:
  otlp:
    otlpEndpoint: "https://collector.staging.miggo.io:4317"

extraEnvs:
- name: K8S_READ_METRIC_OTLP_AUTH_HEADER
  value: Basic <masked>
- name: K8S_READ_OTLP_AUTH_HEADER
  value: Basic <masked>
```

The customer use its own docker registry, so no need for imagePullSecrets at all. In addition the user pass the otlp auth header directly to the POD, no need for the otlp-secret. 

The PR just making sure that in that scenario we don't try to create or use non-existing secret.