### PR TITLE
support init containers

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -126,5 +126,4 @@ jobs:
           commit_message: "[AUTO GITHUB] Bump chart versions"
           branch: ${{ github.head_ref }}
           file_pattern: 'charts/*/Chart.yaml'
-          push_options: '--retry 5'
           create_branch: false

--- a/.github/workflows/run-helm-docs.yaml
+++ b/.github/workflows/run-helm-docs.yaml
@@ -56,5 +56,4 @@ jobs:
           commit_message: "[AUTO GITHUB] Chart README.md"
           branch: ${{ github.head_ref }}
           file_pattern: 'charts/*/README.md'
-          push_options: '--retry 5'
           create_branch: false

--- a/charts/k8s-integration/Chart.yaml
+++ b/charts/k8s-integration/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: k8s-integration
 description: A Helm chart for miggo's k8s-integration
 type: application
-version: 0.0.26
+version: 0.0.27
 appVersion: "0.0.1"

--- a/charts/k8s-integration/README.md
+++ b/charts/k8s-integration/README.md
@@ -85,6 +85,7 @@ The following table lists the configurable parameters of the k8s-integration cha
 | collector.image.pullPolicy | string | `nil` | Image pull policy. Specifies when Kubernetes should pull the container image  |
 | collector.image.repository | string | `"miggoprod/miggo-infra-agent"` | Image repository |
 | collector.image.tag | string | `"latest"` | Image tag (defaults to Chart appVersion if not set) |
+| collector.initContainers | list | `[]` | InitContainers to initialize the pod |
 | collector.labels | object | `{}` | Component-specific labels |
 | collector.podAnnotations | object | `{}` | Component-specific pod annotations |
 | collector.podLabels | object | `{}` | Component-specific pod labels |

--- a/charts/k8s-integration/templates/collector/deployment.yaml
+++ b/charts/k8s-integration/templates/collector/deployment.yaml
@@ -52,6 +52,10 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "k8s-integrations.serviceAccountName" . }}-collector
+      {{- if .Values.collector.initContainers }}
+      initContainers:
+        {{ toYaml .Values.collector.initContainers | nindent 8 }}
+      {{- end }}
       containers:
         - name: miggo-collector
           securityContext:

--- a/charts/k8s-integration/tests/envs/values.yaml
+++ b/charts/k8s-integration/tests/envs/values.yaml
@@ -48,7 +48,6 @@ sensor:
     - name: component
       value: sensor
   
-    
   extraEnvsFrom:
     - configMapRef:
         name: sensor-cm

--- a/charts/k8s-integration/tests/init-containers/test.yaml
+++ b/charts/k8s-integration/tests/init-containers/test.yaml
@@ -1,0 +1,33 @@
+suite: manual secrets injection
+
+release:
+  name: miggo
+  namespace: miggo-space
+
+templates:
+  - templates/k8s-read/deployment.yaml
+  - templates/static-sbom/deployment.yaml
+  - templates/sensor/daemonset.yaml
+  - templates/collector/deployment.yaml
+  - templates/collector/collector-config-cm.yaml
+  - templates/image-pull-secret.yaml
+  - templates/access-key-secret.yaml
+
+values:
+  - values.yaml
+
+tests:
+  - it: collector deployment
+    template: templates/collector/deployment.yaml
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 1
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: busybox
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: MIGGO_ACCESS_KEY
+            value: test

--- a/charts/k8s-integration/tests/init-containers/values.yaml
+++ b/charts/k8s-integration/tests/init-containers/values.yaml
@@ -1,0 +1,22 @@
+miggo:
+  tenantId: "1b4a61e8-cdc8-4174-87bf-8201406ee65e"
+  projectId: "8f74294c-c769-4746-b1f3-cc20eecf0149"
+  clusterName: "simple-test"
+
+k8sRead:
+  enabled: false
+
+staticSbom:
+  enabled: false
+
+sensor:
+  enabled: false
+
+collector:
+  enabled: true
+  initContainers:
+    - name: init-access-key
+      image: busybox
+      env:
+      - name: MIGGO_ACCESS_KEY
+        value: "test"

--- a/charts/k8s-integration/values.yaml
+++ b/charts/k8s-integration/values.yaml
@@ -243,6 +243,8 @@ collector:
   volumes: []
   # -- Additional volume mounts
   volumeMounts: []
+  # -- InitContainers to initialize the pod
+  initContainers: []
 
   image:
     # -- Image repository


### PR DESCRIPTION
```
initContainers:
    - name: init-access-key
      image: busybox
      command: ["/bin/sh", "-c"]
      args:
        - echo "$MIGGO_ACCESS_KEY" > /mnt/access-key/key
      env:
      - name: MIGGO_ACCESS_KEY
        value: "<masked>"
      volumeMounts:
      - name: access-key-volume
        mountPath: /mnt/access-key
    volumeMounts:
      - name: access-key-volume
        mountPath: /etc/miggo-access-key
        subPath: key
    volumes:
      - name: access-key-volume
        emptyDir: {}
```