### PR TITLE
reduce collector resources

### DIFF
--- a/charts/k8s-integration/Chart.yaml
+++ b/charts/k8s-integration/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: k8s-integration
 description: A Helm chart for miggo's k8s-integration
 type: application
-version: 0.0.35
+version: 0.0.36
 appVersion: "0.0.1"

--- a/charts/k8s-integration/README.md
+++ b/charts/k8s-integration/README.md
@@ -1,6 +1,6 @@
 # K8s Integration Helm Chart
 
-![Version: 0.0.35](https://img.shields.io/badge/Version-0.0.35-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.0.36](https://img.shields.io/badge/Version-0.0.36-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 This Helm chart deploys Miggo's Kubernetes integration components, providing comprehensive monitoring, security, and observability capabilities for your Kubernetes clusters.
 

--- a/charts/k8s-integration/README.md
+++ b/charts/k8s-integration/README.md
@@ -90,7 +90,7 @@ The following table lists the configurable parameters of the k8s-integration cha
 | collector.labels | object | `{}` | Component-specific labels |
 | collector.podAnnotations | object | `{}` | Component-specific pod annotations |
 | collector.podLabels | object | `{}` | Component-specific pod labels |
-| collector.resources | object | `{"limits":{"cpu":"500m","memory":"2Gi"},"requests":{"cpu":"250m","memory":"1Gi"}}` | Resource requirements |
+| collector.resources | object | `{"limits":{"cpu":"100m","memory":"500Mi"},"requests":{"cpu":"10m","memory":"200Mi"}}` | Resource requirements |
 | collector.service.annotations | object | `{}` | Service annotations |
 | collector.service.labels | object | `{}` | Service labels |
 | collector.service.ports | list | `[{"name":"http","port":4318,"protocol":"TCP","targetPort":4318},{"name":"grpc","port":4317,"protocol":"TCP","targetPort":4317}]` | Service ports |

--- a/charts/k8s-integration/templates/collector/deployment.yaml
+++ b/charts/k8s-integration/templates/collector/deployment.yaml
@@ -82,8 +82,8 @@ spec:
           {{- end }}
           env:
           {{- if and (.Values.collector.useGOMEMLIMIT) ((((.Values.collector.resources).limits).memory))  }}
-          - name: GOMEMLIMIT
-            value: {{ include "gomemlimit" .Values.collector.resources.limits.memory | quote }}
+            - name: GOMEMLIMIT
+              value: {{ include "gomemlimit" .Values.collector.resources.limits.memory | quote }}
           {{- end }}
           {{- with .Values.extraEnvs }}
             {{- toYaml . | nindent 12 }}

--- a/charts/k8s-integration/tests/runtime-profiler/test.yaml
+++ b/charts/k8s-integration/tests/runtime-profiler/test.yaml
@@ -30,67 +30,20 @@ tests:
     asserts:
       - isKind:
           of: ConfigMap
-      - equal:
+      - matchRegex:
           path: data["config.yaml"]
-          value: |
-            extensions:
-              health_check:
-                endpoint: 0.0.0.0:6666
-              oauth2client:
-                client_id: P2UjsJwOFdIeUAtW0pGTJ5SeJAlq
-                client_secret_file: /etc/miggo-access-key
-                token_url: https://api.descope.com/oauth2/v1/token
-                timeout: 1m
+          pattern: |
+            .*otlphttp/profiles:
+              +endpoint: https://api.miggo.io
+              +auth:
+                +authenticator: oauth2client.*
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: |
+            .*profiles:
+              +receivers: \[otlp\]
+              +exporters: \[otlphttp/profiles\].*
 
-            receivers:
-              otlp:
-                protocols:
-                  grpc:
-                    endpoint: "0.0.0.0:4317"
-                  http:
-                    endpoint: "0.0.0.0:4318"
-
-            processors:
-              batch:
-                timeout: 10s
-
-            exporters:
-
-              debug:
-                verbosity:
-
-              prometheus:
-                endpoint: 0.0.0.0:8889
-
-              otlphttp:
-                traces_endpoint: https://api.miggo.io/v1/traces
-                metrics_endpoint: https://api.miggo.io/v1/metrics
-                logs_endpoint: https://api.miggo.io/v1/logs
-                auth:
-                  authenticator: oauth2client
-              otlphttp/profiles:
-                endpoint: https://api.miggo.io
-                auth:
-                  authenticator: oauth2client
-
-            service:
-              extensions: [health_check, oauth2client]
-              pipelines:
-                profiles:
-                  receivers: [otlp]
-                  exporters: [otlphttp/profiles]
-                metrics:
-                  receivers: [otlp]
-                  processors: [batch]
-                  exporters: [debug, prometheus, otlphttp]
-                traces:
-                  receivers: [otlp]
-                  processors: [batch]
-                  exporters: [debug, otlphttp]
-                logs:
-                  receivers: [otlp]
-                  processors: [batch]
-                  exporters: [debug, otlphttp]
   - it: should add both miggo-sensor and profiler containers to the DaemonSet spec
     template: templates/sensor/daemonset.yaml
     asserts:

--- a/charts/k8s-integration/values.yaml
+++ b/charts/k8s-integration/values.yaml
@@ -362,11 +362,11 @@ collector:
   # -- Resource requirements
   resources:
     limits:
-      cpu: 500m
-      memory: 2Gi
+      cpu: 100m
+      memory: 500Mi
     requests:
-      cpu: 250m
-      memory: 1Gi
+      cpu: 10m
+      memory: 200Mi
 
   service:
     # -- Service type


### PR DESCRIPTION
This PR reduces the default resource allocation for the collector in the Helm chart based on actual usage metrics rather than initial estimates.

Resource usage is being actively monitored through our dashboard (see screenshot below), allowing us to change it if required

![image](https://github.com/user-attachments/assets/d7ec820e-0b75-4ae4-b572-1998f0d4d83e)
