### PR TITLE
add node name + collector component status

### DIFF
--- a/charts/miggo/Chart.yaml
+++ b/charts/miggo/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: miggo
 description: A Helm chart for Miggo
 type: application
-version: 0.0.3
+version: 0.0.4
 appVersion: "v25.403.1"

--- a/charts/miggo/templates/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/templates/miggo-collector/collector-config-cm.yaml
@@ -34,14 +34,29 @@ data:
                   regex: 'otelcol_(.*)'
                   target_label: __name__
                   replacement: 'miggocol_$1'
-                - target_label: "tenant_id"
+                - target_label: "tenant-id"
                   replacement: "{{ .Values.miggo.tenantId }}"
-                - target_label: "project_id"
+                - target_label: "project-id"
                   replacement: "{{ .Values.miggo.projectId }}"
-                - target_label: "miggo_name"
+                - target_label: "miggo-name"
                   replacement: "{{ .Values.miggo.clusterName }}"
+                - target_label: "node-name"
+                  replacement: "${env:NODE_NAME}"
+                - target_label: "deployment-type"
+                  replacement: "{{ if .Values.miggoCollector.instancePerNode }}daemonset{{ else }}deployment{{ end }}"
 
     processors:
+      metricstransform:
+        transforms:
+          - include: miggocol_process_uptime
+            match_type: strict
+            new_name: miggo_component_status
+            action: combine
+            operations:
+              - action: add_label
+                new_label: component
+                new_value: collector
+
       batch:
         timeout: 10s
 
@@ -74,9 +89,13 @@ data:
           receivers: [otlp]
           exporters: [otlphttp/profiles]
         {{- end }}
-        metrics:
-          receivers: [otlp, prometheus]
+        metrics/sensors:
+          receivers: [otlp]
           processors: [batch]
+          exporters: [debug, prometheus, otlphttp]
+        metrics/collector:
+          receivers: [prometheus]
+          processors: [batch, metricstransform]
           exporters: [debug, prometheus, otlphttp]
         traces:
           receivers: [otlp]

--- a/charts/miggo/templates/miggo-scanner/deployment.yaml
+++ b/charts/miggo/templates/miggo-scanner/deployment.yaml
@@ -91,6 +91,10 @@ spec:
           {{- toYaml . | nindent 10 }}
           {{- end }}
           env:
+            - name: MIGGO_SCANNER_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           {{- if and (.Values.miggoScanner.useGOMEMLIMIT) ((((.Values.miggoScanner.resources).limits).memory))  }}
             - name: GOMEMLIMIT
               value: {{ include "gomemlimit" .Values.miggoScanner.resources.limits.memory | quote }}

--- a/charts/miggo/templates/miggo-watch/deployment.yaml
+++ b/charts/miggo/templates/miggo-watch/deployment.yaml
@@ -86,6 +86,10 @@ spec:
           {{- toYaml . | nindent 10 }}
           {{- end }}
           env:
+            - name: MIGGO_WATCH_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           {{- if and (.Values.miggoWatch.useGOMEMLIMIT) ((((.Values.miggoWatch.resources).limits).memory))  }}
             - name: GOMEMLIMIT
               value: {{ include "gomemlimit" .Values.miggoWatch.resources.limits.memory | quote }}


### PR DESCRIPTION
1. Pass the Node Name from Kubernetes to all components (watch, scanner, runtime)
2. Add the standard `miggo_component_status` to the Collector
3. Standardize the label names of the `miggo_component_status` to match the names in the k8s-integration metrics - will require fixing the existing [Miggo Collector](https://grafana.miggo.io/d/beetx55gls8owe/miggo-collector?orgId=1&from=now-5m&to=now&timezone=browser&var-tenant_id=b3ac1c37-0a65-4796-8029-4f4ceb94ec37) dashboard