### PR TITLE
feat(runtime): Introduce GOMEMLIMIT for runtime components

### DIFF
--- a/.github/workflows/run-unittests.yaml
+++ b/.github/workflows/run-unittests.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install helm unittest plugin
         run: |
-          helm plugin install https://github.com/quintush/helm-unittest
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git
 
       - name: Run tests for modified charts
         run: |

--- a/charts/miggo/Chart.yaml
+++ b/charts/miggo/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: miggo
 description: A Helm chart for Miggo
 type: application
-version: 0.0.65
+version: 0.0.66
 appVersion: "v25.713.1"

--- a/charts/miggo/README.md
+++ b/charts/miggo/README.md
@@ -126,6 +126,7 @@ The following table lists the configurable parameters of the miggo chart and the
 | miggoRuntime.analyzer.resources.requests.cpu | string | `"100m"` |  |
 | miggoRuntime.analyzer.resources.requests.memory | string | `"256Mi"` |  |
 | miggoRuntime.analyzer.securityContext.privileged | bool | `true` |  |
+| miggoRuntime.analyzer.useGOMEMLIMIT | bool | `false` | When enabled, the chart will set the GOMEMLIMIT env var to 80% of the configured resources.limits.memory. If no resources.limits.memory are defined then enabling does nothing. It is HIGHLY recommend to enable this setting and set a value for resources.limits.memory. |
 | miggoRuntime.enableFileAccessTracing | bool | `false` | Enable tracing file access. |
 | miggoRuntime.enableNetworkTracing | bool | `false` | Enable tracing network connections. |
 | miggoRuntime.enabled | bool | `false` | Install eBPF agent on each cluster node to provide package-level reachability analysis and other runtime insights. |
@@ -157,11 +158,13 @@ The following table lists the configurable parameters of the miggo chart and the
 | miggoRuntime.profiler.securityContext.allowPrivilegeEscalation | bool | `true` |  |
 | miggoRuntime.profiler.securityContext.capabilities.add[0] | string | `"SYS_ADMIN"` |  |
 | miggoRuntime.profiler.securityContext.privileged | bool | `true` |  |
+| miggoRuntime.profiler.useGOMEMLIMIT | bool | `false` | When enabled, the chart will set the GOMEMLIMIT env var to 80% of the configured resources.limits.memory. If no resources.limits.memory are defined then enabling does nothing. It is HIGHLY recommend to enable this setting and set a value for resources.limits.memory. |
 | miggoRuntime.resources.limits.cpu | string | `"500m"` |  |
 | miggoRuntime.resources.limits.memory | string | `"512Mi"` |  |
 | miggoRuntime.resources.requests.cpu | string | `"100m"` |  |
 | miggoRuntime.resources.requests.memory | string | `"256Mi"` |  |
 | miggoRuntime.securityContext.privileged | bool | `true` |  |
+| miggoRuntime.useGOMEMLIMIT | bool | `false` | When enabled, the chart will set the GOMEMLIMIT env var to 80% of the configured resources.limits.memory. If no resources.limits.memory are defined then enabling does nothing. It is HIGHLY recommend to enable this setting and set a value for resources.limits.memory. |
 | miggoRuntime.volumeMounts | list | `[]` | Additional volume mounts for all containers |
 | miggoRuntime.volumes | list | `[]` |  |
 | miggoScanner.annotations | object | `{}` | Component-specific annotations |

--- a/charts/miggo/templates/miggo-runtime/daemonset.yaml
+++ b/charts/miggo/templates/miggo-runtime/daemonset.yaml
@@ -80,6 +80,10 @@ spec:
           {{- toYaml . | nindent 10 }}
           {{- end }}
           env:
+          {{- if and .Values.miggoRuntime.useGOMEMLIMIT .Values.miggoRuntime.resources.limits.memory }}
+          - name: GOMEMLIMIT
+            value: {{ include "gomemlimit" .Values.miggoRuntime.resources.limits.memory | quote }}
+          {{- end }}
           - name: MIGGO_RUNTIME_NODE_NAME
             valueFrom:
               fieldRef:
@@ -153,6 +157,10 @@ spec:
             - -probabilistic-threshold={{ .Values.miggoRuntime.profiler.probabilisticThreshold }}
             - -probabilistic-interval={{ .Values.miggoRuntime.profiler.probabilisticInterval }}
           env:
+          {{- if and .Values.miggoRuntime.profiler.useGOMEMLIMIT .Values.miggoRuntime.profiler.resources.limits.memory  }}
+            - name: GOMEMLIMIT
+              value: {{ include "gomemlimit" .Values.miggoRuntime.profiler.resources.limits.memory | quote }}
+          {{- end }}
             - name: MIGGO_RUNTIME_CLUSTER_NAME
               value: {{ .Values.miggo.clusterName }}
             - name: MIGGO_RUNTIME_EXPORT_METRICS_ENDPOINT
@@ -199,6 +207,10 @@ spec:
             - --api-url={{ (include "apiEndpoint" . )}}
             {{ end }}
           env:
+          {{- if and .Values.miggoRuntime.analyzer.useGOMEMLIMIT .Values.miggoRuntime.analyzer.resources.limits.memory }}
+            - name: GOMEMLIMIT
+              value: {{ include "gomemlimit" .Values.miggoRuntime.analyzer.resources.limits.memory | quote }}
+          {{- end }}
             - name: RUNTIME_ANALYZER_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/charts/miggo/tests/various-config/test.yaml
+++ b/charts/miggo/tests/various-config/test.yaml
@@ -27,7 +27,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[?(@.name == "miggo-watch")].args
           content: --exclude=pod, statefulset
-  
+
   - it: miggo-scanner config
     template: templates/miggo-scanner/deployment.yaml
     asserts:
@@ -46,10 +46,29 @@ tests:
       - contains:
           path: spec.template.spec.containers[?(@.name == "miggo-scanner")].args
           content: --cache-cm-name=test
-  
+
   - it: miggo-runtime config
     template: templates/miggo-runtime/daemonset.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[?(@.name == "miggo-runtime")].args
           content: --metric-interval=1h
+
+  - it: miggo-runtime useGOMEMLIMIT
+    template: templates/miggo-runtime/daemonset.yaml
+    set:
+      miggoRuntime:
+        useGOMEMLIMIT: false
+        analyzer:
+          useGOMEMLIMIT: true
+          enabled: true
+        profiler:
+          useGOMEMLIMIT: true
+          enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[?(@.name == "miggo-runtime")].env[?(@.name == "GOMEMLIMIT")]
+      - exists:
+          path: spec.template.spec.containers[?(@.name == "profiler")].env[?(@.name == "GOMEMLIMIT")]
+      - exists:
+          path: spec.template.spec.containers[?(@.name == "analyzer")].env[?(@.name == "GOMEMLIMIT")]

--- a/charts/miggo/values.yaml
+++ b/charts/miggo/values.yaml
@@ -252,6 +252,12 @@ miggoRuntime:
   nodeSelector:
     kubernetes.io/os: linux
 
+  # -- When enabled, the chart will set the GOMEMLIMIT env var to 80% of the
+  # configured resources.limits.memory. If no resources.limits.memory are
+  # defined then enabling does nothing. It is HIGHLY recommend to enable this
+  # setting and set a value for resources.limits.memory.
+  useGOMEMLIMIT: false
+
   resources:
     requests:
       cpu: 100m
@@ -282,6 +288,12 @@ miggoRuntime:
       fullPath:
       # -- Image pull policy. Specifies when Kubernetes should pull the container image
       pullPolicy:
+
+    # -- When enabled, the chart will set the GOMEMLIMIT env var to 80% of the
+    # configured resources.limits.memory. If no resources.limits.memory are
+    # defined then enabling does nothing. It is HIGHLY recommend to enable this
+    # setting and set a value for resources.limits.memory.
+    useGOMEMLIMIT: false
 
     resources:
       requests:
@@ -333,6 +345,12 @@ miggoRuntime:
       fullPath:
       # -- Image pull policy. Specifies when Kubernetes should pull the container image
       pullPolicy:
+
+    # -- When enabled, the chart will set the GOMEMLIMIT env var to 80% of the
+    # configured resources.limits.memory. If no resources.limits.memory are
+    # defined then enabling does nothing. It is HIGHLY recommend to enable this
+    # setting and set a value for resources.limits.memory.
+    useGOMEMLIMIT: false
 
     resources:
       requests:


### PR DESCRIPTION
The helm chart now features a `useGOMEMLIMIT` for each runtime component, that allows setting the GOMEMLIMIT env variable for runtime containers. This setting is disabled by default for now (we might enable it after some more testing).

The main idea here is to reduce the amount of OOMs, by letting the golang runtime know, how much memory it has available.

Towards: MIG-7790