### PR TITLE
fix(analyzer): add missing delete verb to analyzer-role

### DIFF
--- a/charts/miggo/Chart.yaml
+++ b/charts/miggo/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: miggo
 description: A Helm chart for Miggo
 type: application
-version: 0.0.88
+version: 0.0.89
 appVersion: "v25.813.1"

--- a/charts/miggo/templates/miggo-runtime/role.yaml
+++ b/charts/miggo/templates/miggo-runtime/role.yaml
@@ -61,4 +61,5 @@ rules:
   - watch
   - list
   - create
+  - delete
 {{- end }}


### PR DESCRIPTION
In order to delete jobs when they run into the timeout, the analzyer role needs the `delete` verb. It has hence been added.