### PR TITLE
fix(ci): remove cancel-in-progress from concurreny group

### DIFF
--- a/.github/workflows/run-helm-docs.yaml
+++ b/.github/workflows/run-helm-docs.yaml
@@ -14,7 +14,6 @@ permissions:
 concurrency:
   # Prevent race condition with any other actions that push changes to the branch
   group: ${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
 
 jobs:
   generate-helm-docs:


### PR DESCRIPTION
The flag will cause jobs of different workflows to cancel out each other. It has hence been removed.