### PR TITLE
miggo: Add .Values.miggoRuntime.affinity.

### DIFF
--- a/charts/miggo/Chart.yaml
+++ b/charts/miggo/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: miggo
 description: A Helm chart for Miggo
 type: application
-version: 0.0.106
+version: 0.0.107
 appVersion: "v25.901.1"

--- a/charts/miggo/templates/miggo-runtime/daemonset.yaml
+++ b/charts/miggo/templates/miggo-runtime/daemonset.yaml
@@ -294,9 +294,14 @@ spec:
       {{- with .Values.miggoRuntime.nodeSelector }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- if or .Values.affinity .Values.miggoRuntime.affinity }}
       affinity:
+        {{- with .Values.affinity }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.miggoRuntime.affinity }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- if or .Values.tolerations .Values.miggoRuntime.tolerations }}
       tolerations:

--- a/charts/miggo/values.yaml
+++ b/charts/miggo/values.yaml
@@ -258,6 +258,10 @@ miggoRuntime:
   # .Values.tolerations will be merged with this list.
   tolerations: []
 
+  # -- Affinity settings for the miggo-runtime DaemonSet. Global affinity specified in
+  # .Values.affinity will be merged with this configuration.
+  affinity: {}
+
   # -- When enabled, the chart will set the GOMEMLIMIT env var to 80% of the
   # configured resources.limits.memory. If no resources.limits.memory are
   # defined then enabling does nothing. It is HIGHLY recommend to enable this


### PR DESCRIPTION
## Description
This PR allows a user to configure affinities that are specific to the `runtime` _DaemonSet_.  Previously, only "global" affinities were supported which were applied to all _Deployments_ and _DaemonSets_ in this chart.

To avoid a breaking change, this PR will merge both `.Values.affinity` and `.Values.miggoRuntime.affinity`.

## Chart Information
- **Chart Name:** `miggo`

## Type of Change
- [x] Chart version bump
- [ ] Bug fix
- [x] Feature addition
- [ ] Documentation update

## Testing
- [ ] `helm lint` passes
- [ ] `helm template` renders successfully
- [ ] Chart installs/upgrades without issues
- [ ] Tested on Kubernetes

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)
