### PR TITLE
DO-345: Make auth URL configurable via config.authUrl

### DIFF
--- a/charts/miggo/Chart.yaml
+++ b/charts/miggo/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: miggo
 description: A Helm chart for Miggo
 type: application
-version: 0.0.174
+version: 0.0.175
 appVersion: "v26.326.2"

--- a/charts/miggo/README.md
+++ b/charts/miggo/README.md
@@ -1,6 +1,6 @@
 # Miggo Helm Chart
 
-![Version: 0.0.174](https://img.shields.io/badge/Version-0.0.174-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.326.2](https://img.shields.io/badge/AppVersion-v26.326.2-informational?style=flat-square)
+![Version: 0.0.175](https://img.shields.io/badge/Version-0.0.175-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.326.2](https://img.shields.io/badge/AppVersion-v26.326.2-informational?style=flat-square)
 
 This Helm chart deploys Miggo's components, providing comprehensive monitoring, security, and observability capabilities for your Kubernetes clusters.
 
@@ -77,6 +77,7 @@ The following table lists the configurable parameters of the miggo chart and the
 | config.accessKey | string | `""` | Access key for authentication (ignored when accessKeySecret is specified) |
 | config.accessKeySecret | string | `""` | Name of the secret containing the access key. Leave empty to create default secrets based on config.accessKey |
 | config.allowedNamespaces | string | `nil` | List of namespaces that are allowed to be processed If empty, all namespaces are included by default (before applying deniedNamespaces) Example: ["development", "staging", "production"] |
+| config.authUrl | string | `"https://auth.miggo.io"` | Base URL for the authentication service (Descope) |
 | config.clientId | string | `"P2UjsJwOFdIeUAtW0pGTJ5SeJAlq"` | Client ID for authentication |
 | config.deniedNamespaces | string | `nil` | List of namespaces that should be excluded from processing Takes precedence over allowedNamespaces - if a namespace is both allowed and denied, it will be denied Example: ["test", "deprecated"] |
 | config.includeSystemNamespaces | bool | `false` | When set to true, includes system namespaces like kube-system etc. When false (default), automatically adds system namespaces to deniedNamespaces It's recommended to keep this false unless you specifically need to operate on system namespaces |

--- a/charts/miggo/files/collector-init-script.sh
+++ b/charts/miggo/files/collector-init-script.sh
@@ -44,6 +44,7 @@ validate_environment() {
         "ACCESS_KEY_MOUNT_LOCATION"
         "CONFIG_TEMPLATE_PATH"
         "CONFIG_OUTPUT_PATH"
+        "AUTH_BASE_URL"
     )
     
     for var in "${required_vars[@]}"; do
@@ -105,7 +106,7 @@ make_api_request() {
         if response=$(curl -s -w "\n%{http_code}" \
             --max-time "$TIMEOUT" \
             --retry 0 \
-            -X POST "https://auth.miggo.io/v1/auth/accesskey/exchange" \
+            -X POST "${AUTH_BASE_URL}/v1/auth/accesskey/exchange" \
             -H "Authorization: Bearer ${client_id}:${access_key}" \
             -H "Content-Type: application/json" 2>/dev/null); then
             

--- a/charts/miggo/templates/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/templates/miggo-collector/collector-config-cm.yaml
@@ -15,7 +15,7 @@ data:
       oauth2client:
         client_id: {{ .Values.config.clientId }}
         client_secret_file: {{ .Values.miggoCollector.accessKeyMountLocation }}
-        token_url: https://auth.miggo.io/oauth2/v1/token
+        token_url: {{ .Values.config.authUrl }}/oauth2/v1/token
         timeout: 1m
       
       {{- with .Values.miggoCollector.extraExtensions }}

--- a/charts/miggo/templates/miggo-collector/deployment.yaml
+++ b/charts/miggo/templates/miggo-collector/deployment.yaml
@@ -88,7 +88,9 @@ spec:
             - name: API_HEALTH_URL
               value: {{ .Values.output.otlp.otlpEndpoint }}/health/status
             - name: OAUTH2_TOKEN_URL
-              value: https://auth.miggo.io/oauth2/v1/token
+              value: {{ .Values.config.authUrl }}/oauth2/v1/token
+            - name: AUTH_BASE_URL
+              value: {{ .Values.config.authUrl }}
           {{- with .Values.extraEnvs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/miggo/values.yaml
+++ b/charts/miggo/values.yaml
@@ -33,6 +33,9 @@ config:
   # -- Client ID for authentication
   clientId: P2UjsJwOFdIeUAtW0pGTJ5SeJAlq
 
+  # -- Base URL for the authentication service (Descope)
+  authUrl: "https://auth.miggo.io"
+
   # -- Access key for authentication (ignored when accessKeySecret is specified)
   accessKey: ""
 


### PR DESCRIPTION
## Summary

- Add `config.authUrl` value (default: `https://auth.miggo.io`) to make the Descope authentication base URL configurable.
- Replaces three hardcoded references to `https://auth.miggo.io` across the collector config template, init container env vars, and init script.

## Context

The playground cluster sends data to the pre-production environment, which uses a different Descope project (`P3AnoZ7B3mdhRAK60OGcK623pj1I`) hosted at `auth.pre-production.miggo.io`. With the auth URL hardcoded to `auth.miggo.io`, the collector's OAuth2 token exchange fails with 403 PermissionDenied when exporting to the pre-production API.

## Changes

| File | Change |
|---|---|
| `values.yaml` | Add `config.authUrl` with default `https://auth.miggo.io` |
| `collector-config-cm.yaml` | Use `config.authUrl` for `oauth2client.token_url` |
| `deployment.yaml` | Pass `OAUTH2_TOKEN_URL` and `AUTH_BASE_URL` env vars from `config.authUrl` |
| `collector-init-script.sh` | Use `AUTH_BASE_URL` env var instead of hardcoded URL for access key exchange |

## Usage

Override in values to point to a different auth endpoint:

```yaml
config:
  authUrl: "https://auth.pre-production.miggo.io"
```

## Validation

- `helm lint` passes
- `helm template` renders correctly with both default and overridden values
- All 61 existing unit tests pass (`helm unittest`)
- All 13 test suites template cleanly

## Test plan

- [ ] Verify default behavior is unchanged (no value set = `https://auth.miggo.io`)
- [ ] Set `config.authUrl: https://auth.pre-production.miggo.io` in playground values and confirm collector init + OAuth2 token exchange succeed
- [ ] Confirm collector exports metrics/traces/logs to pre-production API without 403

Made with [Cursor](https://cursor.com)