### PR TITLE
SEN-414: Centralize sensor endpoints via config.collectorUrl and config.apiUrl

### DIFF
--- a/charts/miggo/Chart.yaml
+++ b/charts/miggo/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: miggo
 description: A Helm chart for Miggo
 type: application
-version: 0.0.177
+version: 0.0.178
 appVersion: "v26.331.1"

--- a/charts/miggo/README.md
+++ b/charts/miggo/README.md
@@ -1,6 +1,6 @@
 # Miggo Helm Chart
 
-![Version: 0.0.177](https://img.shields.io/badge/Version-0.0.177-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.331.1](https://img.shields.io/badge/AppVersion-v26.331.1-informational?style=flat-square)
+![Version: 0.0.178](https://img.shields.io/badge/Version-0.0.178-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.331.1](https://img.shields.io/badge/AppVersion-v26.331.1-informational?style=flat-square)
 
 This Helm chart deploys Miggo's components, providing comprehensive monitoring, security, and observability capabilities for your Kubernetes clusters.
 
@@ -77,8 +77,10 @@ The following table lists the configurable parameters of the miggo chart and the
 | config.accessKey | string | `""` | Access key for authentication (ignored when accessKeySecret is specified) |
 | config.accessKeySecret | string | `""` | Name of the secret containing the access key. Leave empty to create default secrets based on config.accessKey |
 | config.allowedNamespaces | string | `nil` | List of namespaces that are allowed to be processed If empty, all namespaces are included by default (before applying deniedNamespaces) Example: ["development", "staging", "production"] |
+| config.apiUrl | string | `"https://api.miggo.io"` | Miggo API base URL used by sensor components for health checks and other API calls. Decoupled from collectorUrl so OTLP and API traffic can terminate at different hosts. Takes precedence over the deprecated output.api.apiEndpoint. |
 | config.authUrl | string | `"https://auth.miggo.io"` | Base URL for the authentication service (Descope) |
 | config.clientId | string | `"P2UjsJwOFdIeUAtW0pGTJ5SeJAlq"` | Client ID for authentication |
+| config.collectorUrl | string | `"https://collector.miggo.io"` | Upstream URL where the in-cluster miggo-collector forwards OTel data. Takes precedence over the deprecated output.otlp.otlpEndpoint. |
 | config.deniedNamespaces | string | `nil` | List of namespaces that should be excluded from processing Takes precedence over allowedNamespaces - if a namespace is both allowed and denied, it will be denied Example: ["test", "deprecated"] |
 | config.includeSystemNamespaces | bool | `false` | When set to true, includes system namespaces like kube-system etc. When false (default), automatically adds system namespaces to deniedNamespaces It's recommended to keep this false unless you specifically need to operate on system namespaces |
 | config.metrics.interval | string | `"60s"` | Interval for metrics collection |
@@ -240,9 +242,9 @@ The following table lists the configurable parameters of the miggo chart and the
 | miggoWatch.volumes | list | `[]` | Additional volumes |
 | namespaceOverride | string | `""` | Override the namespace where resources are deployed. If not set, uses Release.Namespace |
 | nodeSelector | object | `{}` | Node selector for all pods |
-| output.api.apiEndpoint | string | `""` | Miggo Api endpoint (defaults to otlp endpoint) |
+| output.api.apiEndpoint | string | `""` | Deprecated. Use config.apiUrl instead. Consulted only as a fallback when config.apiUrl is unset, for backward compatibility. |
 | output.api.enabled | bool | `true` | Decide whether to communicate with Miggo Api |
-| output.otlp.otlpEndpoint | string | `"https://api.miggo.io"` | OTLP endpoint URL |
+| output.otlp.otlpEndpoint | string | `""` | Deprecated. Use config.collectorUrl instead. Consulted only as a fallback when config.collectorUrl is unset, for backward compatibility. |
 | output.otlp.tlsSkipVerify | bool | `false` | Skip TLS verification |
 | output.stdout | bool | `false` | Enable stdout logging (for debugging) |
 | podAnnotations | object | `{}` | Pod annotations to add to all pods |

--- a/charts/miggo/templates/_helpers.tpl
+++ b/charts/miggo/templates/_helpers.tpl
@@ -76,11 +76,19 @@ access-key-secret
 {{- end -}}
 {{- end -}}
 
+{{- define "collectorUrl" -}}
+{{- .Values.config.collectorUrl | default .Values.output.otlp.otlpEndpoint -}}
+{{- end -}}
+
+{{- define "apiUrl" -}}
+{{- .Values.config.apiUrl | default .Values.output.api.apiEndpoint | default .Values.output.otlp.otlpEndpoint -}}
+{{- end -}}
+
 {{- define "otlpEndpoint" -}}
 {{- if .Values.miggoCollector.enabled -}}
 http://miggo-collector.{{ include "miggo.namespace" . }}.svc.cluster.local:4318
 {{- else -}}
-{{ .Values.output.otlp.otlpEndpoint }}
+{{ include "collectorUrl" . }}
 {{- end -}}
 {{- end -}}
 
@@ -89,18 +97,14 @@ miggo-collector.{{ include "miggo.namespace" . }}.svc.cluster.local
 {{- end -}}
 
 {{- define "apiEndpoint" -}}
-{{- if .Values.output.api.apiEndpoint -}}
-{{- .Values.output.api.apiEndpoint  -}}
-{{- else -}}
-{{ .Values.output.otlp.otlpEndpoint }}
-{{- end -}}
+{{ include "apiUrl" . }}
 {{- end -}}
 
 {{- define "otlpProfilesEndpoint" -}}
 {{- if .Values.miggoCollector.enabled -}}
 miggo-collector.{{ include "miggo.namespace" . }}.svc.cluster.local:4317
 {{- else -}}
-{{ .Values.output.otlp.otlpEndpoint }}
+{{ include "collectorUrl" . }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/miggo/templates/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/templates/miggo-collector/collector-config-cm.yaml
@@ -154,14 +154,14 @@ data:
         endpoint: 0.0.0.0:8889
 
       otlphttp:
-        traces_endpoint: {{ .Values.output.otlp.otlpEndpoint }}/v1/traces
-        metrics_endpoint: {{ .Values.output.otlp.otlpEndpoint }}/v1/metrics
-        logs_endpoint: {{ .Values.output.otlp.otlpEndpoint }}/v1/logs
+        traces_endpoint: {{ include "collectorUrl" . }}/v1/traces
+        metrics_endpoint: {{ include "collectorUrl" . }}/v1/metrics
+        logs_endpoint: {{ include "collectorUrl" . }}/v1/logs
         auth:
           authenticator: oauth2client
       {{- if .Values.miggoRuntime.profiler.enabled }}
       otlphttp/profiles:
-        endpoint: {{ .Values.output.otlp.otlpEndpoint }}
+        endpoint: {{ include "collectorUrl" . }}
         auth:
           authenticator: oauth2client
       {{- end }}

--- a/charts/miggo/templates/miggo-collector/deployment.yaml
+++ b/charts/miggo/templates/miggo-collector/deployment.yaml
@@ -86,7 +86,7 @@ spec:
             - name: ACCESS_KEY_MOUNT_LOCATION
               value: {{ .Values.miggoCollector.accessKeyMountLocation }}
             - name: API_HEALTH_URL
-              value: {{ .Values.output.otlp.otlpEndpoint }}/health/status
+              value: {{ include "apiUrl" . }}/health/status
             - name: OAUTH2_TOKEN_URL
               value: {{ .Values.config.authUrl }}/oauth2/v1/token
             - name: AUTH_BASE_URL

--- a/charts/miggo/tests/endpoints/test.yaml
+++ b/charts/miggo/tests/endpoints/test.yaml
@@ -1,0 +1,214 @@
+suite: endpoint configuration (config.collectorUrl, config.apiUrl, legacy fallbacks)
+
+release:
+  name: miggo
+  namespace: miggo-space
+
+templates:
+  - templates/miggo-collector/deployment.yaml
+  - templates/miggo-collector/collector-config-cm.yaml
+  - templates/miggo-watch/deployment.yaml
+  - templates/miggo-runtime/daemonset.yaml
+  - templates/miggo-runtime/fluent-bit-cm.yaml
+
+values:
+  - values.yaml
+
+tests:
+  # ---------- Happy path: defaults propagate ----------
+
+  - it: should point collector-config otlphttp exporters at config.collectorUrl default
+    template: templates/miggo-collector/collector-config-cm.yaml
+    asserts:
+      - matchRegex:
+          path: data["config-template.yaml"]
+          pattern: |
+            .*otlphttp:
+              +traces_endpoint: https://collector\.miggo\.io/v1/traces
+              +metrics_endpoint: https://collector\.miggo\.io/v1/metrics
+              +logs_endpoint: https://collector\.miggo\.io/v1/logs.*
+      - matchRegex:
+          path: data["config-template.yaml"]
+          pattern: |
+            .*otlphttp/profiles:
+              +endpoint: https://collector\.miggo\.io.*
+
+  - it: should set API_HEALTH_URL from config.apiUrl default
+    template: templates/miggo-collector/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[?(@.name == "collector-init-container")].env
+          content:
+            name: API_HEALTH_URL
+            value: https://api.miggo.io/health/status
+
+  - it: should set OAUTH2_TOKEN_URL and AUTH_BASE_URL from config.authUrl default
+    template: templates/miggo-collector/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[?(@.name == "collector-init-container")].env
+          content:
+            name: OAUTH2_TOKEN_URL
+            value: https://auth.miggo.io/oauth2/v1/token
+      - contains:
+          path: spec.template.spec.initContainers[?(@.name == "collector-init-container")].env
+          content:
+            name: AUTH_BASE_URL
+            value: https://auth.miggo.io
+
+  - it: should pass config.apiUrl to miggo-watch via --api-url
+    template: templates/miggo-watch/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "miggo-watch")].args
+          content: --api-url=https://api.miggo.io
+
+  - it: should pass config.apiUrl to miggo-runtime analyzer via --api-url
+    template: templates/miggo-runtime/daemonset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "analyzer")].args
+          content: --api-url=https://api.miggo.io
+
+  # ---------- Custom values: explicit overrides propagate ----------
+
+  - it: should propagate custom config.collectorUrl into collector-config exporters
+    template: templates/miggo-collector/collector-config-cm.yaml
+    set:
+      config:
+        collectorUrl: https://my-collector.example.com
+    asserts:
+      - matchRegex:
+          path: data["config-template.yaml"]
+          pattern: |
+            .*otlphttp:
+              +traces_endpoint: https://my-collector\.example\.com/v1/traces
+              +metrics_endpoint: https://my-collector\.example\.com/v1/metrics
+              +logs_endpoint: https://my-collector\.example\.com/v1/logs.*
+      - matchRegex:
+          path: data["config-template.yaml"]
+          pattern: |
+            .*otlphttp/profiles:
+              +endpoint: https://my-collector\.example\.com.*
+
+  - it: should send sensor components to config.collectorUrl when miggoCollector disabled
+    template: templates/miggo-watch/deployment.yaml
+    set:
+      miggoCollector:
+        enabled: false
+      config:
+        collectorUrl: https://my-collector.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "miggo-watch")].args
+          content: --otlp-endpoint=https://my-collector.example.com
+
+  - it: should propagate custom config.apiUrl to API_HEALTH_URL
+    template: templates/miggo-collector/deployment.yaml
+    set:
+      config:
+        apiUrl: https://my-api.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[?(@.name == "collector-init-container")].env
+          content:
+            name: API_HEALTH_URL
+            value: https://my-api.example.com/health/status
+
+  - it: should propagate custom config.apiUrl to miggo-watch --api-url
+    template: templates/miggo-watch/deployment.yaml
+    set:
+      config:
+        apiUrl: https://my-api.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "miggo-watch")].args
+          content: --api-url=https://my-api.example.com
+
+  # ---------- Back-compat: legacy keys still honored as fallbacks ----------
+
+  - it: should fall back to output.otlp.otlpEndpoint when config.collectorUrl is unset
+    template: templates/miggo-collector/collector-config-cm.yaml
+    set:
+      config:
+        collectorUrl: ""
+      output:
+        otlp:
+          otlpEndpoint: https://legacy-upstream.example.com
+    asserts:
+      - matchRegex:
+          path: data["config-template.yaml"]
+          pattern: |
+            .*otlphttp:
+              +traces_endpoint: https://legacy-upstream\.example\.com/v1/traces.*
+
+  - it: should fall back to output.api.apiEndpoint when config.apiUrl is unset
+    template: templates/miggo-collector/deployment.yaml
+    set:
+      config:
+        apiUrl: ""
+      output:
+        api:
+          apiEndpoint: https://legacy-api.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[?(@.name == "collector-init-container")].env
+          content:
+            name: API_HEALTH_URL
+            value: https://legacy-api.example.com/health/status
+
+  - it: new config.collectorUrl should win over legacy output.otlp.otlpEndpoint when both are set
+    template: templates/miggo-collector/collector-config-cm.yaml
+    set:
+      config:
+        collectorUrl: https://new.example.com
+      output:
+        otlp:
+          otlpEndpoint: https://legacy.example.com
+    asserts:
+      - matchRegex:
+          path: data["config-template.yaml"]
+          pattern: |
+            .*otlphttp:
+              +traces_endpoint: https://new\.example\.com/v1/traces.*
+      - notMatchRegex:
+          path: data["config-template.yaml"]
+          pattern: legacy\.example\.com
+
+  # ---------- Regression guard on the mis-propagation bug ----------
+  # Customer overrides collector URL but leaves api URL at default.
+  # Previously this silently routed API calls through the collector URL;
+  # now apiUrl has its own default so the two stay independent.
+
+  - it: should NOT leak custom config.collectorUrl into API_HEALTH_URL
+    template: templates/miggo-collector/deployment.yaml
+    set:
+      config:
+        collectorUrl: https://custom-collector.example.com
+      output:
+        api:
+          apiEndpoint: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[?(@.name == "collector-init-container")].env
+          content:
+            name: API_HEALTH_URL
+            value: https://api.miggo.io/health/status
+      - notContains:
+          path: spec.template.spec.initContainers[?(@.name == "collector-init-container")].env
+          content:
+            name: API_HEALTH_URL
+            value: https://custom-collector.example.com/health/status
+
+  - it: should NOT leak custom config.collectorUrl into miggo-watch --api-url
+    template: templates/miggo-watch/deployment.yaml
+    set:
+      config:
+        collectorUrl: https://custom-collector.example.com
+      output:
+        api:
+          apiEndpoint: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "miggo-watch")].args
+          content: --api-url=https://api.miggo.io

--- a/charts/miggo/tests/endpoints/values.yaml
+++ b/charts/miggo/tests/endpoints/values.yaml
@@ -1,0 +1,21 @@
+miggo:
+  clusterName: "endpoints-test"
+
+config:
+  accessKey: "test-access-key"
+
+miggoWatch:
+  enabled: true
+
+miggoScanner:
+  enabled: true
+
+miggoRuntime:
+  enabled: true
+  analyzer:
+    enabled: true
+  profiler:
+    enabled: true
+
+miggoCollector:
+  enabled: true

--- a/charts/miggo/tests/runtime-profiler/test.yaml
+++ b/charts/miggo/tests/runtime-profiler/test.yaml
@@ -35,7 +35,7 @@ tests:
           path: data["config-template.yaml"]
           pattern: |
             .*otlphttp/profiles:
-              +endpoint: https://api.miggo.io
+              +endpoint: https://collector.miggo.io
               +auth:
                 +authenticator: oauth2client.*
       - matchRegex:

--- a/charts/miggo/values.yaml
+++ b/charts/miggo/values.yaml
@@ -36,6 +36,16 @@ config:
   # -- Base URL for the authentication service (Descope)
   authUrl: "https://auth.miggo.io"
 
+  # -- Upstream URL where the in-cluster miggo-collector forwards OTel data.
+  # Takes precedence over the deprecated output.otlp.otlpEndpoint.
+  collectorUrl: "https://collector.miggo.io"
+
+  # -- Miggo API base URL used by sensor components for health checks and
+  # other API calls. Decoupled from collectorUrl so OTLP and API traffic can
+  # terminate at different hosts. Takes precedence over the deprecated
+  # output.api.apiEndpoint.
+  apiUrl: "https://api.miggo.io"
+
   # -- Access key for authentication (ignored when accessKeySecret is specified)
   accessKey: ""
 
@@ -63,15 +73,17 @@ output:
   stdout: false
 
   otlp:
-    # -- OTLP endpoint URL
-    otlpEndpoint: "https://api.miggo.io"
+    # -- Deprecated. Use config.collectorUrl instead. Consulted only as a
+    # fallback when config.collectorUrl is unset, for backward compatibility.
+    otlpEndpoint: ""
     # -- Skip TLS verification
     tlsSkipVerify: false
 
   api:
     # -- Decide whether to communicate with Miggo Api
     enabled: true
-    # -- Miggo Api endpoint (defaults to otlp endpoint)
+    # -- Deprecated. Use config.apiUrl instead. Consulted only as a fallback
+    # when config.apiUrl is unset, for backward compatibility.
     apiEndpoint: ""
 
 serviceAccount:


### PR DESCRIPTION
Resolves SEN-414.

## Description

Continues [DO-345](https://github.com/miggo-io/miggo-helm-charts/pull/201). That PR made `auth.miggo.io` configurable via `config.authUrl`. This does the same treatment for the other two logical endpoints the sensor stack talks to:

- **`config.collectorUrl`** (default `https://collector.miggo.io`) — the upstream URL the in-cluster `miggo-collector` exports OTel data to. Previously wired through `output.otlp.otlpEndpoint`, which was confusingly named (`otlp`) and defaulted (`https://api.miggo.io`) — an *api* host serving as the *collector* destination.
- **`config.apiUrl`** (default `https://api.miggo.io`) — the Miggo API base URL sensor components use for health checks and other API calls. Previously wired through `output.api.apiEndpoint` with an **empty** default and a silent fallback to the OTLP endpoint. Any customer overriding `output.otlp.otlpEndpoint` without also overriding `output.api.apiEndpoint` silently routed API calls through the OTLP URL — the mis-propagation this PR fixes.

Also decouples `API_HEALTH_URL` in the collector init container from the OTLP endpoint (now derived from `config.apiUrl`, was `{{ otlpEndpoint }}/health/status`).

## Chart Information
- **Chart Name:** `miggo`

## Type of Change
- [ ] Chart version bump
- [x] Bug fix
- [x] Feature addition
- [ ] Documentation update

## What changed
- `values.yaml` — added `config.collectorUrl` + `config.apiUrl` with real defaults; marked `output.otlp.otlpEndpoint` / `output.api.apiEndpoint` deprecated with empty defaults.
- `templates/_helpers.tpl` — added `collectorUrl` / `apiUrl` helpers with a `| default` fallback chain to the legacy keys; rewrote `otlpEndpoint`, `otlpProfilesEndpoint`, `apiEndpoint` to delegate to them.
- `templates/miggo-collector/collector-config-cm.yaml` — otlphttp traces/metrics/logs and otlphttp/profiles exporters now use `include "collectorUrl" .`.
- `templates/miggo-collector/deployment.yaml` — `API_HEALTH_URL` env var now derived from `include "apiUrl" .` instead of the OTLP endpoint.

## Migration
Existing installs continue to work unchanged: `output.otlp.otlpEndpoint` and `output.api.apiEndpoint` are still honored as fallbacks when the new `config.*Url` keys are unset. New installs should prefer the new keys. The precedence is `config.collectorUrl` → `output.otlp.otlpEndpoint` and `config.apiUrl` → `output.api.apiEndpoint` → `output.otlp.otlpEndpoint`.

## Testing
- [x] `helm lint` passes
- [x] `helm template` renders successfully (spot-checked propagation of custom values into collector ConfigMap exporters, init container env, and sensor CLI args)
- [x] All 84 unit tests pass (15 suites, including 14 new)
- [ ] Tested on Kubernetes

New `tests/endpoints/` suite covers:
- **Happy path (defaults)**: `should point collector-config otlphttp exporters at config.collectorUrl default`; `should set API_HEALTH_URL from config.apiUrl default`; `should set OAUTH2_TOKEN_URL and AUTH_BASE_URL from config.authUrl default`; `should pass config.apiUrl to miggo-watch via --api-url`; `should pass config.apiUrl to miggo-runtime analyzer via --api-url`.
- **Custom values**: `should propagate custom config.collectorUrl into collector-config exporters`; `should send sensor components to config.collectorUrl when miggoCollector disabled`; `should propagate custom config.apiUrl to API_HEALTH_URL`; `should propagate custom config.apiUrl to miggo-watch --api-url`.
- **Back-compat / precedence**: `should fall back to output.otlp.otlpEndpoint when config.collectorUrl is unset`; `should fall back to output.api.apiEndpoint when config.apiUrl is unset`; `new config.collectorUrl should win over legacy output.otlp.otlpEndpoint when both are set`.
- **Regression guard on the mis-propagation bug**: `should NOT leak custom config.collectorUrl into API_HEALTH_URL`; `should NOT leak custom config.collectorUrl into miggo-watch --api-url`.

Existing `tests/runtime-profiler/test.yaml` assertion updated for the new collector default.

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below)

The default *value* of `output.otlp.otlpEndpoint` changes from `https://api.miggo.io` to `""` (empty), but the effective default is now `https://collector.miggo.io` via `config.collectorUrl`. Customers who explicitly set `output.otlp.otlpEndpoint` in their values file are unaffected (their value still takes precedence over the new key's default via the fallback chain, as validated by the new back-compat tests).

## Out of scope
- Renaming/removing the legacy `output.otlp.otlpEndpoint` / `output.api.apiEndpoint` keys (kept indefinitely as deprecated fallbacks).
- The two hardcoded-default fallbacks in `collector-init-script.sh` lines 369-370 (`${OAUTH2_TOKEN_URL:-https://auth.miggo.io/...}` and `${API_HEALTH_URL:-https://api.miggo.io/...}`) — intentionally left; those env vars are always set by the deployment template in practice.
- `miggo-operator/` chart (uses its own `k8sread.otlp.otlpEndpoint`; separate refactor).
- DNS/infra work to make `collector.miggo.io` resolvable — customers can override via values until the DNS is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)