### PR TITLE
relable node and pod attrs to match the names coming from the sensors

### DIFF
--- a/charts/miggo/Chart.yaml
+++ b/charts/miggo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: miggo
 description: A Helm chart for Miggo
 type: application
-version: 0.0.182
+version: 0.0.183
 appVersion: "v26.428.1"
 maintainers:
   - name: miggo-io

--- a/charts/miggo/README.md
+++ b/charts/miggo/README.md
@@ -1,6 +1,6 @@
 # Miggo Helm Chart
 
-![Version: 0.0.182](https://img.shields.io/badge/Version-0.0.182-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.428.1](https://img.shields.io/badge/AppVersion-v26.428.1-informational?style=flat-square)
+![Version: 0.0.183](https://img.shields.io/badge/Version-0.0.183-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.428.1](https://img.shields.io/badge/AppVersion-v26.428.1-informational?style=flat-square)
 
 This Helm chart deploys Miggo's components, providing comprehensive monitoring, security, and observability capabilities for your Kubernetes clusters.
 

--- a/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
@@ -625,7 +625,7 @@ data:
                 new_value: Miggo Collector
               - action: add_label
                 new_label: chart_version
-                new_value: 0.0.181
+                new_value: 0.0.182
 
       batch/metrics:
         timeout: 10s
@@ -645,6 +645,10 @@ data:
           statements:
             - merge_maps(attributes, resource.attributes, "insert")
             - set(attributes["miggo-name"], "my-cluster")
+            - set(attributes["pod.hostname"], attributes["k8s.pod.name"])
+            - delete_key(attributes, "k8s.pod.name")
+            - set(attributes["node.name"], attributes["k8s.node.name"])
+            - delete_key(attributes, "k8s.node.name")
 
     exporters:
       debug:

--- a/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
@@ -625,7 +625,7 @@ data:
                 new_value: Miggo Collector
               - action: add_label
                 new_label: chart_version
-                new_value: 0.0.182
+                new_value: 0.0.183
 
       batch/metrics:
         timeout: 10s

--- a/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.181
+    helm.sh/chart: miggo-0.0.182
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.428.1"
@@ -23,11 +23,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 756d843e6d14bddcdaaf2630f8419ed1dd3bdbcd2079c76398bed479c982145a
+        checksum/config: 943bd1c98b5c5fa84e0ccd10f42033242ecd9f4e03e00ac6b9ea6abfd424b6e9
       labels:
         component: collector
         miggo.io/app: example-collector
-        helm.sh/chart: miggo-0.0.181
+        helm.sh/chart: miggo-0.0.182
         app.kubernetes.io/name: miggo-collector
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v26.428.1"

--- a/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.182
+    helm.sh/chart: miggo-0.0.183
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.428.1"
@@ -23,11 +23,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 943bd1c98b5c5fa84e0ccd10f42033242ecd9f4e03e00ac6b9ea6abfd424b6e9
+        checksum/config: ca656eda06791183d18843c96c1f5ca59accf8ffc8771afea898d034ffba6f48
       labels:
         component: collector
         miggo.io/app: example-collector
-        helm.sh/chart: miggo-0.0.182
+        helm.sh/chart: miggo-0.0.183
         app.kubernetes.io/name: miggo-collector
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v26.428.1"

--- a/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.181
+    helm.sh/chart: miggo-0.0.182
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.428.1"

--- a/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.182
+    helm.sh/chart: miggo-0.0.183
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.428.1"

--- a/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.181
+    helm.sh/chart: miggo-0.0.182
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.428.1"
@@ -23,7 +23,7 @@ spec:
         checksum/config: 6ed877707581906ad34573544b36de695bd4e68848d208fc2a19372f691cdd49
       labels:
         component: miggo-runtime
-        helm.sh/chart: miggo-0.0.181
+        helm.sh/chart: miggo-0.0.182
         app.kubernetes.io/name: miggo-runtime
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v26.428.1"
@@ -51,7 +51,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.181
+            - --chart-version=0.0.182
             - --disable-profiler=false
             - --enable-network-tracing=false
             - --enable-file-access-tracing=false

--- a/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.182
+    helm.sh/chart: miggo-0.0.183
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.428.1"
@@ -23,7 +23,7 @@ spec:
         checksum/config: 6ed877707581906ad34573544b36de695bd4e68848d208fc2a19372f691cdd49
       labels:
         component: miggo-runtime
-        helm.sh/chart: miggo-0.0.182
+        helm.sh/chart: miggo-0.0.183
         app.kubernetes.io/name: miggo-runtime
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v26.428.1"
@@ -51,7 +51,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.182
+            - --chart-version=0.0.183
             - --disable-profiler=false
             - --enable-network-tracing=false
             - --enable-file-access-tracing=false

--- a/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-pod-watcher-cr
   labels:
-    helm.sh/chart: miggo-0.0.181
+    helm.sh/chart: miggo-0.0.182
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.428.1"

--- a/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-pod-watcher-cr
   labels:
-    helm.sh/chart: miggo-0.0.182
+    helm.sh/chart: miggo-0.0.183
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.428.1"

--- a/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-pod-watcher-crb
   labels:
-    helm.sh/chart: miggo-0.0.181
+    helm.sh/chart: miggo-0.0.182
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.428.1"

--- a/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-pod-watcher-crb
   labels:
-    helm.sh/chart: miggo-0.0.182
+    helm.sh/chart: miggo-0.0.183
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.428.1"

--- a/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.182
+    helm.sh/chart: miggo-0.0.183
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.428.1"

--- a/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.181
+    helm.sh/chart: miggo-0.0.182
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.428.1"

--- a/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.181
+    helm.sh/chart: miggo-0.0.182
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.428.1"
@@ -23,7 +23,7 @@ spec:
       annotations:
       labels:
         component: miggo-scanner
-        helm.sh/chart: miggo-0.0.181
+        helm.sh/chart: miggo-0.0.182
         app.kubernetes.io/name: miggo-scanner
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v26.428.1"
@@ -51,7 +51,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.181
+            - --chart-version=0.0.182
             - --queue-size=10000
             
             - --cache-flush-interval=168h

--- a/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.182
+    helm.sh/chart: miggo-0.0.183
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.428.1"
@@ -23,7 +23,7 @@ spec:
       annotations:
       labels:
         component: miggo-scanner
-        helm.sh/chart: miggo-0.0.182
+        helm.sh/chart: miggo-0.0.183
         app.kubernetes.io/name: miggo-scanner
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v26.428.1"
@@ -51,7 +51,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.182
+            - --chart-version=0.0.183
             - --queue-size=10000
             
             - --cache-flush-interval=168h

--- a/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.181
+    helm.sh/chart: miggo-0.0.182
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.428.1"

--- a/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.182
+    helm.sh/chart: miggo-0.0.183
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.428.1"

--- a/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.182
+    helm.sh/chart: miggo-0.0.183
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.428.1"
@@ -23,7 +23,7 @@ spec:
       annotations:
       labels:
         component: miggo-watch
-        helm.sh/chart: miggo-0.0.182
+        helm.sh/chart: miggo-0.0.183
         app.kubernetes.io/name: miggo-watch
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v26.428.1"
@@ -51,7 +51,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.182
+            - --chart-version=0.0.183
             - --interval=1h
             - --image-tracker-interval=1h
             - --exclude=pod,replica-set

--- a/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.181
+    helm.sh/chart: miggo-0.0.182
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.428.1"
@@ -23,7 +23,7 @@ spec:
       annotations:
       labels:
         component: miggo-watch
-        helm.sh/chart: miggo-0.0.181
+        helm.sh/chart: miggo-0.0.182
         app.kubernetes.io/name: miggo-watch
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v26.428.1"
@@ -51,7 +51,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.181
+            - --chart-version=0.0.182
             - --interval=1h
             - --image-tracker-interval=1h
             - --exclude=pod,replica-set

--- a/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.181
+    helm.sh/chart: miggo-0.0.182
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.428.1"

--- a/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.182
+    helm.sh/chart: miggo-0.0.183
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.428.1"

--- a/charts/miggo/templates/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/templates/miggo-collector/collector-config-cm.yaml
@@ -141,6 +141,10 @@ data:
           statements:
             - merge_maps(attributes, resource.attributes, "insert")
             - set(attributes["miggo-name"], "{{ .Values.miggo.clusterName }}")
+            - set(attributes["pod.hostname"], attributes["k8s.pod.name"])
+            - delete_key(attributes, "k8s.pod.name")
+            - set(attributes["node.name"], attributes["k8s.node.name"])
+            - delete_key(attributes, "k8s.node.name")
 
       {{- with .Values.miggoCollector.extraProcessors }}
       {{- toYaml . | nindent 6 }}


### PR DESCRIPTION
## Description

Relable node and pod attrs to match the names coming from the sensors

## Chart Information

- **Chart Name:** `miggo`

## Type of Change

- [x] Chart version bump
- [x] Bug fix
- [ ] Feature addition
- [ ] Documentation update

## Testing

- [x] `helm lint` passes
- [ ] `helm template` renders successfully
- [ ] Chart installs/upgrades without issues
- [ ] Tested on Kubernetes

## Breaking Changes

- [ ] No breaking changes
- [ ] Breaking changes (describe below)
