### PR TITLE
chore: remove dotnet from default enabled tracers

### DIFF
--- a/charts/miggo/Chart.yaml
+++ b/charts/miggo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: miggo
 description: A Helm chart for Miggo
 type: application
-version: 0.0.185
+version: 0.0.186
 appVersion: "v26.511.1"
 maintainers:
   - name: miggo-io

--- a/charts/miggo/README.md
+++ b/charts/miggo/README.md
@@ -1,6 +1,6 @@
 # Miggo Helm Chart
 
-![Version: 0.0.185](https://img.shields.io/badge/Version-0.0.185-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.511.1](https://img.shields.io/badge/AppVersion-v26.511.1-informational?style=flat-square)
+![Version: 0.0.186](https://img.shields.io/badge/Version-0.0.186-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.511.1](https://img.shields.io/badge/AppVersion-v26.511.1-informational?style=flat-square)
 
 This Helm chart deploys Miggo's components, providing comprehensive monitoring, security, and observability capabilities for your Kubernetes clusters.
 
@@ -165,7 +165,7 @@ The following table lists the configurable parameters of the miggo chart and the
 | miggoRuntime.priorityClassName | string | `""` | Priority class name (defaults to global priorityClassName or system-node-critical) |
 | miggoRuntime.profiler.enableNamespaceFiltering | bool | `true` | Enables namespace-based filtering for the profiler. When enabled, the profiler applies allowedNamespaces and deniedNamespaces configuration to selectively collect profiles based on Kubernetes namespace membership. Note: This feature only works on cgroupv2 systems. |
 | miggoRuntime.profiler.enabled | bool | `true` | Install profiler on each cluster node to provide function-level reachability analysis and other runtime insights. |
-| miggoRuntime.profiler.enabledTracers | list | `["perl","php","python","hotspot","v8","dotnet","go"]` | Specifies which tracers should be enabled in the profiler. The following tracers are currently supported: `perl`, `php`, `python`, `hotspot`, `ruby`, `v8`, `dotnet`, `go`, `labels` |
+| miggoRuntime.profiler.enabledTracers | list | `["perl","php","python","hotspot","v8","go"]` | Specifies which tracers should be enabled in the profiler. The following tracers are currently supported: `perl`, `php`, `python`, `hotspot`, `ruby`, `v8`, `dotnet`, `go`, `labels` |
 | miggoRuntime.profiler.image.fullPath | string | `nil` | Optional full image path override. If set, takes precedence over registry/repository/tag settings. Useful for local development with Minikube or when needing to specify a complete custom image path |
 | miggoRuntime.profiler.image.pullPolicy | string | `nil` | Image pull policy. Specifies when Kubernetes should pull the container image |
 | miggoRuntime.profiler.image.repository | string | `"miggo/miggo-profiler"` | Image repository |

--- a/charts/miggo/tests/runtime-profiler/test.yaml
+++ b/charts/miggo/tests/runtime-profiler/test.yaml
@@ -107,7 +107,7 @@ tests:
             - -monitor-interval=5s
             - -probabilistic-threshold=100
             - -probabilistic-interval=1m0s
-            - -tracers=perl,php,python,hotspot,v8,dotnet,go
+            - -tracers=perl,php,python,hotspot,v8,go
       - equal:
           path: spec.template.spec.containers[?(@.name == "profiler")].securityContext
           value:
@@ -176,4 +176,4 @@ tests:
             - -monitor-interval=5s
             - -probabilistic-threshold=1
             - -probabilistic-interval=1m0s
-            - -tracers=perl,php,python,hotspot,v8,dotnet,go
+            - -tracers=perl,php,python,hotspot,v8,go

--- a/charts/miggo/values.yaml
+++ b/charts/miggo/values.yaml
@@ -344,7 +344,7 @@ miggoRuntime:
     # -- Specifies which tracers should be enabled in the profiler.
     # The following tracers are currently supported:
     # `perl`, `php`, `python`, `hotspot`, `ruby`, `v8`, `dotnet`, `go`, `labels`
-    enabledTracers: [perl, php, python, hotspot, v8, dotnet, go]
+    enabledTracers: [perl, php, python, hotspot, v8, go]
 
     resources:
       requests:


### PR DESCRIPTION
Resolves SEN-441.

## Description

Drop `dotnet` from the default `miggoRuntime.profiler.enabledTracers` list in `charts/miggo/values.yaml`. The two `runtime-profiler/test.yaml` snapshot assertions are updated in lock-step. `charts/miggo/README.md` regenerates via the existing `generate-helm-docs` workflow on merge.

`dotnet` remains in the *supported* tracers comment — users who still want it can re-enable it via a values override (`--set 'miggoRuntime.profiler.enabledTracers={...,dotnet,...}'`).

## Chart Information

- **Chart Name:** `miggo`

## Type of Change

- [ ] Chart version bump
- [ ] Bug fix
- [ ] Feature addition
- [ ] Documentation update
- [x] Default-config change (no version bump; existing installs unaffected until re-deploy)

## Testing

- [x] `helm lint` passes
- [x] `helm template` renders successfully — verified `-tracers=perl,php,python,hotspot,v8,go` (no dotnet) under default values; `--set 'miggoRuntime.profiler.enabledTracers={dotnet}'` override still renders `-tracers=dotnet`.
- [x] `helm unittest -f 'tests/**/test.yaml' .` — 15 suites / 84 tests pass locally
- [ ] Tested on Kubernetes

## Breaking Changes

- [x] No breaking changes (existing installs are unaffected; only new deploys / values-driven upgrades pick up the new default — `dotnet` can be re-enabled via override)
- [ ] Breaking changes (describe below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)