### PR TITLE
feat(helm): add miggoCollector.extraPipelines knob (SEN-444)

### DIFF
--- a/charts/miggo/Chart.yaml
+++ b/charts/miggo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: miggo
 description: A Helm chart for Miggo
 type: application
-version: 0.0.190
+version: 0.0.191
 appVersion: "v26.512.3"
 maintainers:
   - name: miggo-io

--- a/charts/miggo/README.md
+++ b/charts/miggo/README.md
@@ -1,6 +1,6 @@
 # Miggo Helm Chart
 
-![Version: 0.0.190](https://img.shields.io/badge/Version-0.0.190-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.512.3](https://img.shields.io/badge/AppVersion-v26.512.3-informational?style=flat-square)
+![Version: 0.0.191](https://img.shields.io/badge/Version-0.0.191-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.512.3](https://img.shields.io/badge/AppVersion-v26.512.3-informational?style=flat-square)
 
 This Helm chart deploys Miggo's components, providing comprehensive monitoring, security, and observability capabilities for your Kubernetes clusters.
 

--- a/charts/miggo/README.md
+++ b/charts/miggo/README.md
@@ -105,6 +105,7 @@ The following table lists the configurable parameters of the miggo chart and the
 | miggoCollector.extraExporters | object | `{}` | Additional exporter configurations |
 | miggoCollector.extraExtensionNames | list | `[]` | Additional extension names to add to service |
 | miggoCollector.extraExtensions | object | `{}` | Additional extension configurations |
+| miggoCollector.extraPipelines | object | `{}` | Additional OTel collector pipelines, rendered verbatim under service.pipelines. Use this when you need a pipeline that is INDEPENDENT of the chart's primary pipelines (e.g. mirroring telemetry to a second tenant via a separate processor chain + exporter). The extras you wire in here (extensions / processors / exporters) should be declared via the corresponding extra* maps above; do NOT add them to the *Names lists unless you want them appended to the primary pipelines as well. Empty by default — the rendered config is byte-identical to the single-tenant baseline when unset. |
 | miggoCollector.extraProcessorNames | list | `[]` | Additional processor names to add to pipelines |
 | miggoCollector.extraProcessors | object | `{}` | Additional processor configurations |
 | miggoCollector.image.fullPath | string | `nil` | Optional full image path override. If set, takes precedence over registry/repository/tag settings. Useful for local development with Minikube or when needing to specify a complete custom image path |

--- a/charts/miggo/templates/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/templates/miggo-collector/collector-config-cm.yaml
@@ -344,4 +344,8 @@ data:
             {{- range .Values.miggoCollector.extraExporterNames }}
             - {{ . }}
             {{- end }}
+
+        {{- with .Values.miggoCollector.extraPipelines }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
 {{ end }}

--- a/charts/miggo/tests/extra-pipelines/test.yaml
+++ b/charts/miggo/tests/extra-pipelines/test.yaml
@@ -1,0 +1,134 @@
+suite: miggoCollector.extraPipelines — generic escape hatch for independent pipelines
+
+release:
+  name: miggo
+  namespace: miggo-space
+
+templates:
+  - templates/miggo-collector/collector-config-cm.yaml
+
+values:
+  - values.yaml
+
+tests:
+  # ---------- Happy path: extraPipelines content lands verbatim under service.pipelines ----------
+
+  - it: should render every extraPipelines key under service.pipelines
+    set:
+      miggoCollector:
+        extraPipelines:
+          traces/prod:
+            receivers: [otlp]
+            processors: [batch/traces]
+            exporters: [otlphttp]
+          logs/prod:
+            receivers: [otlp]
+            processors: [batch/logs]
+            exporters: [otlphttp]
+    asserts:
+      - matchRegex:
+          path: data["config-template.yaml"]
+          pattern: "(?s)service:.*pipelines:.*traces/prod:"
+      - matchRegex:
+          path: data["config-template.yaml"]
+          pattern: "(?s)service:.*pipelines:.*logs/prod:"
+
+  - it: should wire prod processors and exporter into traces/prod
+    set:
+      miggoCollector:
+        extraProcessors:
+          resource/prod:
+            attributes:
+              - key: tenant
+                value: "07125897-d3ed-489b-889b-66a466183f01"
+                action: upsert
+          attributes/prod:
+            actions:
+              - key: tenant
+                value: "07125897-d3ed-489b-889b-66a466183f01"
+                action: upsert
+        extraExporters:
+          otlphttp/prod:
+            traces_endpoint: https://collector.miggo.io/v1/traces
+        extraPipelines:
+          traces/prod:
+            receivers: [otlp]
+            processors: [batch/traces, resource/prod, attributes/prod]
+            exporters: [otlphttp/prod]
+    asserts:
+      # traces/prod block contains each expected processor and the prod exporter.
+      # Non-greedy `.*?` keeps each match scoped near the traces/prod key so it
+      # can't accidentally satisfy on the primary pipeline's tokens.
+      - matchRegex:
+          path: data["config-template.yaml"]
+          pattern: "(?s)traces/prod:.*?- otlphttp/prod"
+      - matchRegex:
+          path: data["config-template.yaml"]
+          pattern: "(?s)traces/prod:.*?- batch/traces"
+      - matchRegex:
+          path: data["config-template.yaml"]
+          pattern: "(?s)traces/prod:.*?- resource/prod"
+      - matchRegex:
+          path: data["config-template.yaml"]
+          pattern: "(?s)traces/prod:.*?- attributes/prod"
+
+  - it: should add oauth2client/prod to service.extensions when listed in extraExtensionNames
+    set:
+      miggoCollector:
+        extraExtensionNames:
+          - oauth2client/prod
+        extraExtensions:
+          oauth2client/prod:
+            client_id: TEST_CLIENT_ID
+            client_secret_file: /etc/miggo-prod-access-key
+            token_url: https://auth.miggo.io/oauth2/v1/token
+            timeout: 1m
+    asserts:
+      - matchRegex:
+          path: data["config-template.yaml"]
+          pattern: "(?s)extensions:.*- oauth2client/prod"
+
+  # ---------- Regression guard: with no extras set at all, primary pipelines and config are unchanged ----------
+
+  - it: primary traces pipeline must remain unchanged when no extras are set
+    # baseline values.yaml sets NO extras, so this test inherits a clean state.
+    asserts:
+      - matchRegex:
+          path: data["config-template.yaml"]
+          pattern: "(?s)traces:.*?- batch/traces"
+      - matchRegex:
+          path: data["config-template.yaml"]
+          pattern: "(?s)traces:.*?- otlphttp"
+      - matchRegex:
+          path: data["config-template.yaml"]
+          pattern: "(?s)traces:.*?- debug"
+
+  - it: must not emit any /prod pipeline keys when no extras are set
+    asserts:
+      - notMatchRegex:
+          path: data["config-template.yaml"]
+          pattern: "traces/prod:"
+      - notMatchRegex:
+          path: data["config-template.yaml"]
+          pattern: "logs/prod:"
+      - notMatchRegex:
+          path: data["config-template.yaml"]
+          pattern: "otlphttp/prod"
+
+  # ---------- Composability: legacy extra*Names still appends to primary pipelines ----------
+
+  - it: legacy extraExporterNames still appends the named exporter to the primary traces pipeline
+    set:
+      miggoCollector:
+        extraExporters:
+          custom-debug:
+            verbosity: detailed
+        extraExporterNames:
+          - custom-debug
+    asserts:
+      - matchRegex:
+          path: data["config-template.yaml"]
+          pattern: "(?s)traces:.*?- custom-debug"
+      - matchRegex:
+          path: data["config-template.yaml"]
+          pattern: "(?s)logs:.*?- custom-debug"

--- a/charts/miggo/tests/extra-pipelines/values.yaml
+++ b/charts/miggo/tests/extra-pipelines/values.yaml
@@ -1,0 +1,11 @@
+miggo:
+  clusterName: "extra-pipelines-test"
+
+config:
+  accessKey: "d6918ba5-b727-4d51-bae5-31c2a8ba59cb98944bab-d97a-4e3a-9b22-dae633070ba9"
+
+miggoCollector:
+  enabled: true
+
+miggoRuntime:
+  enabled: true

--- a/charts/miggo/values.yaml
+++ b/charts/miggo/values.yaml
@@ -493,6 +493,22 @@ miggoCollector:
   # -- Additional extension names to add to service
   extraExtensionNames: []
 
+  # -- Additional OTel collector pipelines, rendered verbatim under
+  # service.pipelines. Use this when you need a pipeline that is INDEPENDENT
+  # of the chart's primary pipelines (e.g. mirroring telemetry to a second
+  # tenant via a separate processor chain + exporter). The extras you wire
+  # in here (extensions / processors / exporters) should be declared via the
+  # corresponding extra* maps above; do NOT add them to the *Names lists
+  # unless you want them appended to the primary pipelines as well. Empty
+  # by default — the rendered config is byte-identical to the single-tenant
+  # baseline when unset.
+  extraPipelines: {}
+  # extraPipelines:
+  #   traces/prod:
+  #     receivers: [otlp]
+  #     processors: [batch/traces, resource/prod, attributes/prod]
+  #     exporters: [otlphttp/prod]
+
   # -- An internal locaiton to mount the access key file within the container
   accessKeyMountLocation: /etc/miggo-access-key
 


### PR DESCRIPTION
Resolves SEN-444.

## Summary
- Adds `miggoCollector.extraPipelines` (default `{}`) — a generic escape hatch rendered verbatim under `service.pipelines:` in the collector configmap.
- Lets customers define OTel pipelines that are independent of the chart's primary pipelines (no shared processor chain). The intended use case is fanning telemetry out to a second tenant/project, but the chart stays tenant-agnostic — the customer composes the extension / processors / exporter using the existing `extra*` maps.
- When `extraPipelines` is unset, the rendered config is byte-identical to today's output. Verified via `helm template` diff on a minimal values file and on `apps/demo/demo/values/miggo.yaml` (the only in-tree consumer of the legacy `extra*` API).

## Why
Today's `extra*` API only appends to the primary pipelines, sharing their processor chain. A customer that needs to ship telemetry to a second tenant has no way to give that exporter its own tenant tags — data ends up in the primary tenant regardless. Discovered debugging the demo cluster's dual-tenant setup (`Demo / Dev` → `DemoV2 / Production`): backend streamers route by data attribute (`record_data.tenant`), so without per-exporter tagging the second tenant's UI is permanently empty.

## Test plan
- [x] New `helm-unittest` suite `charts/miggo/tests/extra-pipelines/` covers:
  - **Happy path** — `extraPipelines` content renders verbatim under `service.pipelines:`; per-pipeline processors and exporters are wired correctly; `oauth2client/<name>` listed in `extraExtensionNames` lands in `service.extensions`.
  - **Regression guard** — with no extras set at all, the primary `traces:` pipeline still contains `batch/traces` / `otlphttp` / `debug`, and no `/prod` pipeline keys or `otlphttp/prod` exporter leak into the rendered config.
  - **Back-compat** — legacy `extraExporterNames` still appends the named exporter to the primary pipelines (`traces:`, `logs:`).
- [x] `./charts/miggo/run-tests.sh` passes locally: **16 suites pass, 93 tests, 0 fail**.
- [x] `helm lint` clean for both the new test values and the demo cluster's current legacy values (regression sanity).
- [x] `helm template` diff confirmed empty when `extraPipelines` is unset (1809 → 1809 lines unchanged on `apps/demo/demo/values/miggo.yaml`).

## Out of scope
- Migration of `apps/demo/demo/values/miggo.yaml` to use `extraPipelines` — separate gitops PR follow-up.
- Chart version bump — handled automatically by `.github/workflows/bump-version.yaml` on merge.
- README regeneration — handled by `.github/workflows/run-helm-docs.yaml` on merge.