### PR TITLE
dotnet lre cache params

### DIFF
--- a/charts/miggo/Chart.yaml
+++ b/charts/miggo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: miggo
 description: A Helm chart for Miggo
 type: application
-version: 0.0.189
+version: 0.0.190
 appVersion: "v26.512.3"
 maintainers:
   - name: miggo-io

--- a/charts/miggo/README.md
+++ b/charts/miggo/README.md
@@ -1,6 +1,6 @@
 # Miggo Helm Chart
 
-![Version: 0.0.189](https://img.shields.io/badge/Version-0.0.189-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.512.3](https://img.shields.io/badge/AppVersion-v26.512.3-informational?style=flat-square)
+![Version: 0.0.190](https://img.shields.io/badge/Version-0.0.190-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.512.3](https://img.shields.io/badge/AppVersion-v26.512.3-informational?style=flat-square)
 
 This Helm chart deploys Miggo's components, providing comprehensive monitoring, security, and observability capabilities for your Kubernetes clusters.
 
@@ -166,6 +166,10 @@ The following table lists the configurable parameters of the miggo chart and the
 | miggoRuntime.kubernetesClusterDomain | string | `""` | Kubernetes cluster domain |
 | miggoRuntime.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector settings |
 | miggoRuntime.priorityClassName | string | `""` | Priority class name (defaults to global priorityClassName or system-node-critical) |
+| miggoRuntime.profiler.dotnet.peCacheSize | string | `nil` | Max entries in the PE info LRU cache (MIGGO_DOTNET_PE_CACHE_SIZE). Leave empty to use the profiler default. |
+| miggoRuntime.profiler.dotnet.peCacheTTL | string | `nil` | TTL for entries in the PE info LRU cache (MIGGO_DOTNET_PE_CACHE_TTL), e.g. "5m". Leave empty to use the profiler default. |
+| miggoRuntime.profiler.dotnet.stringsCacheSize | string | `nil` | Max entries in the PE strings LRU cache (MIGGO_DOTNET_STRINGS_CACHE_SIZE). Leave empty to use the profiler default. |
+| miggoRuntime.profiler.dotnet.stringsCacheTTL | string | `nil` | TTL for entries in the PE strings LRU cache (MIGGO_DOTNET_STRINGS_CACHE_TTL), e.g. "10m". Leave empty to use the profiler default. |
 | miggoRuntime.profiler.enableNamespaceFiltering | bool | `true` | Enables namespace-based filtering for the profiler. When enabled, the profiler applies allowedNamespaces and deniedNamespaces configuration to selectively collect profiles based on Kubernetes namespace membership. Note: This feature only works on cgroupv2 systems. |
 | miggoRuntime.profiler.enabled | bool | `true` | Install profiler on each cluster node to provide function-level reachability analysis and other runtime insights. |
 | miggoRuntime.profiler.enabledTracers | list | `["perl","php","python","hotspot","v8","go"]` | Specifies which tracers should be enabled in the profiler. The following tracers are currently supported: `perl`, `php`, `python`, `hotspot`, `ruby`, `v8`, `dotnet`, `go`, `labels` |

--- a/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
@@ -625,7 +625,7 @@ data:
                 new_value: Miggo Collector
               - action: add_label
                 new_label: chart_version
-                new_value: 0.0.188
+                new_value: 0.0.189
 
       batch/metrics:
         timeout: 10s

--- a/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.188
+    helm.sh/chart: miggo-0.0.189
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.512.3"
@@ -23,11 +23,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ee8110be7e1fe66ee6b7685c9290e413cfb2d48f802d13f49642267a0e268742
+        checksum/config: 75a0f6fa85d03cb407ce1ed482a534d7571dd9ca07196f7d77de0ee046fcbdb1
       labels:
         component: collector
         miggo.io/app: example-collector
-        helm.sh/chart: miggo-0.0.188
+        helm.sh/chart: miggo-0.0.189
         app.kubernetes.io/name: miggo-collector
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v26.512.3"

--- a/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.188
+    helm.sh/chart: miggo-0.0.189
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.512.3"

--- a/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.188
+    helm.sh/chart: miggo-0.0.189
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.512.3"
@@ -23,7 +23,7 @@ spec:
         checksum/config: 6ed877707581906ad34573544b36de695bd4e68848d208fc2a19372f691cdd49
       labels:
         component: miggo-runtime
-        helm.sh/chart: miggo-0.0.188
+        helm.sh/chart: miggo-0.0.189
         app.kubernetes.io/name: miggo-runtime
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v26.512.3"
@@ -51,7 +51,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.188
+            - --chart-version=0.0.189
             - --disable-profiler=false
             - --enable-network-tracing=false
             - --enable-file-access-tracing=false

--- a/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-pod-watcher-cr
   labels:
-    helm.sh/chart: miggo-0.0.188
+    helm.sh/chart: miggo-0.0.189
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.512.3"

--- a/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-pod-watcher-crb
   labels:
-    helm.sh/chart: miggo-0.0.188
+    helm.sh/chart: miggo-0.0.189
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.512.3"

--- a/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.188
+    helm.sh/chart: miggo-0.0.189
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.512.3"

--- a/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.188
+    helm.sh/chart: miggo-0.0.189
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.512.3"
@@ -23,7 +23,7 @@ spec:
       annotations:
       labels:
         component: miggo-scanner
-        helm.sh/chart: miggo-0.0.188
+        helm.sh/chart: miggo-0.0.189
         app.kubernetes.io/name: miggo-scanner
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v26.512.3"
@@ -51,7 +51,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.188
+            - --chart-version=0.0.189
             - --queue-size=10000
             
             - --cache-flush-interval=168h

--- a/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.188
+    helm.sh/chart: miggo-0.0.189
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.512.3"

--- a/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.188
+    helm.sh/chart: miggo-0.0.189
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.512.3"
@@ -23,7 +23,7 @@ spec:
       annotations:
       labels:
         component: miggo-watch
-        helm.sh/chart: miggo-0.0.188
+        helm.sh/chart: miggo-0.0.189
         app.kubernetes.io/name: miggo-watch
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v26.512.3"
@@ -51,7 +51,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.188
+            - --chart-version=0.0.189
             - --interval=1h
             - --image-tracker-interval=1h
             - --exclude=pod,replica-set

--- a/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.188
+    helm.sh/chart: miggo-0.0.189
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.512.3"

--- a/charts/miggo/templates/miggo-runtime/daemonset.yaml
+++ b/charts/miggo/templates/miggo-runtime/daemonset.yaml
@@ -205,6 +205,22 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+          {{- with .Values.miggoRuntime.profiler.dotnet.peCacheSize }}
+            - name: MIGGO_DOTNET_PE_CACHE_SIZE
+              value: {{ . | quote }}
+          {{- end }}
+          {{- with .Values.miggoRuntime.profiler.dotnet.peCacheTTL }}
+            - name: MIGGO_DOTNET_PE_CACHE_TTL
+              value: {{ . | quote }}
+          {{- end }}
+          {{- with .Values.miggoRuntime.profiler.dotnet.stringsCacheSize }}
+            - name: MIGGO_DOTNET_STRINGS_CACHE_SIZE
+              value: {{ . | quote }}
+          {{- end }}
+          {{- with .Values.miggoRuntime.profiler.dotnet.stringsCacheTTL }}
+            - name: MIGGO_DOTNET_STRINGS_CACHE_TTL
+              value: {{ . | quote }}
+          {{- end }}
           {{- with .Values.miggoRuntime.profiler.extraEnvs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/miggo/values.yaml
+++ b/charts/miggo/values.yaml
@@ -382,6 +382,16 @@ miggoRuntime:
     # Note: This feature only works on cgroupv2 systems.
     enableNamespaceFiltering: true
 
+    dotnet:
+      # -- Max entries in the PE info LRU cache (MIGGO_DOTNET_PE_CACHE_SIZE). Leave empty to use the profiler default.
+      peCacheSize:
+      # -- TTL for entries in the PE info LRU cache (MIGGO_DOTNET_PE_CACHE_TTL), e.g. "5m". Leave empty to use the profiler default.
+      peCacheTTL:
+      # -- Max entries in the PE strings LRU cache (MIGGO_DOTNET_STRINGS_CACHE_SIZE). Leave empty to use the profiler default.
+      stringsCacheSize:
+      # -- TTL for entries in the PE strings LRU cache (MIGGO_DOTNET_STRINGS_CACHE_TTL), e.g. "10m". Leave empty to use the profiler default.
+      stringsCacheTTL:
+
   fluentbit:
     # -- Install fluent-bit on each cluster node to forward the profiler logs to the Collector
     enabled: true


### PR DESCRIPTION
## Description

Allow to configure dotnet lru cache 

## Chart Information

- **Chart Name:** `miggo`

## Type of Change

- [x] Chart version bump
- [ ] Bug fix
- [x] Feature addition
- [ ] Documentation update

## Testing

- [x] `helm lint` passes
- [x] `helm template` renders successfully
- [x] Chart installs/upgrades without issues
- [x] Tested on Kubernetes

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes (describe below)
