### PR TITLE
feat(helm): grant miggo-watch RBAC for admission webhook configurations (MIG-11496)

### DIFF
--- a/charts/miggo/Chart.yaml
+++ b/charts/miggo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: miggo
 description: A Helm chart for Miggo
 type: application
-version: 0.0.192
+version: 0.0.193
 appVersion: "v26.517.1"
 maintainers:
   - name: miggo-io

--- a/charts/miggo/README.md
+++ b/charts/miggo/README.md
@@ -1,6 +1,6 @@
 # Miggo Helm Chart
 
-![Version: 0.0.192](https://img.shields.io/badge/Version-0.0.192-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.517.1](https://img.shields.io/badge/AppVersion-v26.517.1-informational?style=flat-square)
+![Version: 0.0.193](https://img.shields.io/badge/Version-0.0.193-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.517.1](https://img.shields.io/badge/AppVersion-v26.517.1-informational?style=flat-square)
 
 This Helm chart deploys Miggo's components, providing comprehensive monitoring, security, and observability capabilities for your Kubernetes clusters.
 

--- a/charts/miggo/examples/default/rendered/miggo-watch/role.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/role.yaml
@@ -28,3 +28,7 @@ rules:
 - apiGroups: ["batch"]
   resources: ["cronjobs", "jobs"]
   verbs: ["get", "list", "watch"]
+
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+  verbs: ["get", "list", "watch"]

--- a/charts/miggo/templates/miggo-watch/role.yaml
+++ b/charts/miggo/templates/miggo-watch/role.yaml
@@ -27,4 +27,8 @@ rules:
 - apiGroups: ["batch"]
   resources: ["cronjobs", "jobs"]
   verbs: ["get", "list", "watch"]
+
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+  verbs: ["get", "list", "watch"]
 {{ end }}


### PR DESCRIPTION
## Description

Adds `admissionregistration.k8s.io/{mutating,validating}webhookconfigurations` `get/list/watch` to `miggo-watch-cluster-role`. Required by [miggo-io/k8s-integrations#557](https://github.com/miggo-io/k8s-integrations/pull/557), which adds the matching exporters in `k8s-read`.

Without this grant, the new exporters would fail every scan with `Forbidden` — `handleExportError` swallows `IsNotFound` (uninstalled CRDs) but **not** `IsForbidden`, so the customer-visible effect is loud error logs and zero rows of the new entity types flowing into ClickHouse, defeating the purpose of the parent ticket.

Resolves MIG-11496 (RBAC half).

## Chart Information

- **Chart Name:** `miggo`

## Type of Change

- [ ] Chart version bump
- [ ] Bug fix
- [x] Feature addition
- [ ] Documentation update

## Testing

- [x] `helm lint` passes
- [x] `helm template` renders successfully (verified the new rule appears in the rendered ClusterRole)
- [x] `helm-unittest`: 93/93 pass
- [x] Rendered example under `examples/default/rendered/miggo-watch/role.yaml` refreshed to match the new template output

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes (describe below)

Pure additive RBAC. Existing permissions unchanged.

## Companion PRs (deploy together)

- [miggo-io/k8s-integrations#557](https://github.com/miggo-io/k8s-integrations/pull/557) — sensor adds the exporters that need this grant.
- [miggo-io/backend-python#3149](https://github.com/miggo-io/backend-python/pull/3149) — streamer accepts the new entity types into `otel.k8s_watch_entities`.
- [miggo-io/ui-modules#2386](https://github.com/miggo-io/ui-modules/pull/2386) — customer-facing `k8s_info.sh` aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)