### PR TITLE
MIG-11558: feat(collector): log key_id/iat/exp on init JWT decode

### DIFF
--- a/charts/miggo/files/collector-init-script.sh
+++ b/charts/miggo/files/collector-init-script.sh
@@ -258,10 +258,18 @@ extract_tenant_info() {
         return 1
     fi
 
+    # Extract JWT identity claims for lifecycle logging (MIG-11558).
+    # sub = Descope access key ID (joins to tenant_access_key.refId).
+    local key_id iat exp
+    key_id=$(echo "$jwt_payload" | jq -r '.sub // empty')
+    iat=$(echo "$jwt_payload" | jq -r '.iat // empty')
+    exp=$(echo "$jwt_payload" | jq -r '.exp // empty')
+
     log_info "Tenant information extracted successfully"
     log_info "Project ID: $project_id"
     log_info "Tenant ID: $tenant_id"
     log_info "Tenant count: $tenant_count"
+    log_info "key_id=$key_id iat=$iat exp=$exp"
 
     # Export environment variables
     export MIGGO_PROJECT_ID="$project_id"


### PR DESCRIPTION
## MIG-11558

The collector init container already decodes the JWT payload from the Descope access-key exchange to extract `project_id` and `tenant_id`. This PR logs three additional claims (`sub`, `iat`, `exp`) from the same decoded payload so collector pod starts appear in the unified key-usage dashboard.

### Why
- `sub` = Descope Access Key ID — joins to `tenant_access_key.refId` in Postgres, identifies which named key the collector was started with
- `iat` + `exp` — enable JWT TTL visibility and rotation detection across the platform

### Change
- `charts/miggo/files/collector-init-script.sh` — three new `jq` reads from the already-decoded payload + one log line

No logic changes — logging only.

Linear: https://linear.app/miggo/issue/MIG-11558

🤖 Generated with [Claude Code](https://claude.com/claude-code)