### PR TITLE
feat(helm): configure timeoutSeconds and failureThreshold for all probes

### DIFF
--- a/charts/miggo/Chart.yaml
+++ b/charts/miggo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: miggo
 description: A Helm chart for Miggo
 type: application
-version: 0.0.199
+version: 0.0.200
 appVersion: "v26.522.1"
 maintainers:
   - name: miggo-io

--- a/charts/miggo/README.md
+++ b/charts/miggo/README.md
@@ -271,8 +271,8 @@ The following table lists the configurable parameters of the miggo chart and the
 | podLabels | object | `{}` | Pod labels to add to all pods |
 | podSecurityContext | object | `{}` | Pod security context for all pods |
 | priorityClassName | string | `""` | Priority class name for all pods |
-| probes.failureThreshold | int | `3` | Failure threshold for liveness and readiness probes across all components |
-| probes.timeoutSeconds | int | `5` | Timeout seconds for liveness and readiness probes across all components |
+| probes.failureThreshold | int | `5` | Failure threshold for liveness and readiness probes across all components |
+| probes.timeoutSeconds | int | `10` | Timeout seconds for liveness and readiness probes across all components |
 | securityContext | object | `{}` | Container security context for all containers |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.automount | bool | `true` | Automatically mount API credentials for the service account |

--- a/charts/miggo/README.md
+++ b/charts/miggo/README.md
@@ -1,6 +1,6 @@
 # Miggo Helm Chart
 
-![Version: 0.0.199](https://img.shields.io/badge/Version-0.0.199-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.522.1](https://img.shields.io/badge/AppVersion-v26.522.1-informational?style=flat-square)
+![Version: 0.0.200](https://img.shields.io/badge/Version-0.0.200-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.522.1](https://img.shields.io/badge/AppVersion-v26.522.1-informational?style=flat-square)
 
 This Helm chart deploys Miggo's components, providing comprehensive monitoring, security, and observability capabilities for your Kubernetes clusters.
 
@@ -119,6 +119,8 @@ The following table lists the configurable parameters of the miggo chart and the
 | miggoCollector.podAnnotations | object | `{}` | Component-specific pod annotations |
 | miggoCollector.podLabels | object | `{}` | Component-specific pod labels |
 | miggoCollector.priorityClassName | string | `""` | Priority class name (defaults to global priorityClassName or system-node-critical) |
+| miggoCollector.probes.failureThreshold | string | `""` | Override global probes.failureThreshold for miggo-collector |
+| miggoCollector.probes.timeoutSeconds | string | `""` | Override global probes.timeoutSeconds for miggo-collector |
 | miggoCollector.replicas | int | `1` | Number of replicas to run (relevant only if instancePerNode: false) |
 | miggoCollector.resources | object | `{"limits":{"cpu":"100m","memory":"500Mi"},"requests":{"cpu":"10m","memory":"200Mi"}}` | Resource requirements |
 | miggoCollector.service.annotations | object | `{}` | Service annotations |
@@ -135,6 +137,8 @@ The following table lists the configurable parameters of the miggo chart and the
 | miggoRuntime.analyzer.image.pullPolicy | string | `nil` | Image pull policy. Specifies when Kubernetes should pull the container image |
 | miggoRuntime.analyzer.image.repository | string | `"miggo/miggo-analyzer"` | Image repository |
 | miggoRuntime.analyzer.image.tag | string | `nil` | Image tag (defaults to Chart appVersion if not set) |
+| miggoRuntime.analyzer.probes.failureThreshold | string | `""` | Override global probes.failureThreshold for miggo-runtime analyzer |
+| miggoRuntime.analyzer.probes.timeoutSeconds | string | `""` | Override global probes.timeoutSeconds for miggo-runtime analyzer |
 | miggoRuntime.analyzer.resources.limits.cpu | string | `"500m"` |  |
 | miggoRuntime.analyzer.resources.limits.memory | string | `"256Mi"` |  |
 | miggoRuntime.analyzer.resources.requests.cpu | string | `"100m"` |  |
@@ -167,6 +171,8 @@ The following table lists the configurable parameters of the miggo chart and the
 | miggoRuntime.kubernetesClusterDomain | string | `""` | Kubernetes cluster domain |
 | miggoRuntime.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector settings |
 | miggoRuntime.priorityClassName | string | `""` | Priority class name (defaults to global priorityClassName or system-node-critical) |
+| miggoRuntime.probes.failureThreshold | string | `""` | Override global probes.failureThreshold for miggo-runtime |
+| miggoRuntime.probes.timeoutSeconds | string | `""` | Override global probes.timeoutSeconds for miggo-runtime |
 | miggoRuntime.profiler.dotnet.peCacheSize | string | `nil` | Max entries in the PE info LRU cache (MIGGO_DOTNET_PE_CACHE_SIZE). Leave empty to use the profiler default. |
 | miggoRuntime.profiler.dotnet.peCacheTTL | string | `nil` | TTL for entries in the PE info LRU cache (MIGGO_DOTNET_PE_CACHE_TTL), e.g. "5m". Leave empty to use the profiler default. |
 | miggoRuntime.profiler.dotnet.stringsCacheSize | string | `nil` | Max entries in the PE strings LRU cache (MIGGO_DOTNET_STRINGS_CACHE_SIZE). Leave empty to use the profiler default. |
@@ -219,6 +225,8 @@ The following table lists the configurable parameters of the miggo chart and the
 | miggoScanner.nodeSelector | object | `{}` | Node selector for miggo-scanner pods. Merged with global nodeSelector. |
 | miggoScanner.podAnnotations | object | `{}` | Component-specific pod annotations |
 | miggoScanner.podLabels | object | `{}` | Component-specific pod labels |
+| miggoScanner.probes.failureThreshold | string | `""` | Override global probes.failureThreshold for miggo-scanner |
+| miggoScanner.probes.timeoutSeconds | string | `""` | Override global probes.timeoutSeconds for miggo-scanner |
 | miggoScanner.resources.limits.cpu | string | `"3000m"` |  |
 | miggoScanner.resources.limits.memory | string | `"4Gi"` |  |
 | miggoScanner.resources.requests.cpu | string | `"1000m"` |  |
@@ -243,6 +251,8 @@ The following table lists the configurable parameters of the miggo chart and the
 | miggoWatch.nodeSelector | object | `{}` | Node selector for miggo-watch pods. Merged with global nodeSelector. |
 | miggoWatch.podAnnotations | object | `{}` | Component-specific pod annotations |
 | miggoWatch.podLabels | object | `{}` | Component-specific pod labels |
+| miggoWatch.probes.failureThreshold | string | `""` | Override global probes.failureThreshold for miggo-watch |
+| miggoWatch.probes.timeoutSeconds | string | `""` | Override global probes.timeoutSeconds for miggo-watch |
 | miggoWatch.resources.limits.cpu | string | `"100m"` |  |
 | miggoWatch.resources.limits.memory | string | `"256Mi"` |  |
 | miggoWatch.resources.requests.cpu | string | `"10m"` |  |
@@ -261,6 +271,8 @@ The following table lists the configurable parameters of the miggo chart and the
 | podLabels | object | `{}` | Pod labels to add to all pods |
 | podSecurityContext | object | `{}` | Pod security context for all pods |
 | priorityClassName | string | `""` | Priority class name for all pods |
+| probes.failureThreshold | int | `3` | Failure threshold for liveness and readiness probes across all components |
+| probes.timeoutSeconds | int | `5` | Timeout seconds for liveness and readiness probes across all components |
 | securityContext | object | `{}` | Container security context for all containers |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.automount | bool | `true` | Automatically mount API credentials for the service account |

--- a/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
@@ -625,7 +625,7 @@ data:
                 new_value: Miggo Collector
               - action: add_label
                 new_label: chart_version
-                new_value: 0.0.198
+                new_value: 0.0.199
 
       batch/metrics:
         timeout: 10s

--- a/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.198
+    helm.sh/chart: miggo-0.0.199
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.519.2"
+    app.kubernetes.io/version: "v26.522.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,14 +23,14 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3d470713c80847192be008f8def640dfe373a0d7d5aead577759e6d7ade1d51d
+        checksum/config: 65e5d7c099e5e4a77421d1529cc64473852b688914c17291321bbb974e056c01
       labels:
         component: collector
         miggo.io/app: example-collector
-        helm.sh/chart: miggo-0.0.198
+        helm.sh/chart: miggo-0.0.199
         app.kubernetes.io/name: miggo-collector
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.519.2"
+        app.kubernetes.io/version: "v26.522.1"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: example-collector
       initContainers:
         - name: collector-init-container
-          image: "registry.miggo.io/miggo/miggo-collector:v26.519.2"
+          image: "registry.miggo.io/miggo/miggo-collector:v26.522.1"
           securityContext:
             {}
           imagePullPolicy: IfNotPresent
@@ -75,7 +75,7 @@ spec:
         - name: miggo-collector
           securityContext:
             {}
-          image: "registry.miggo.io/miggo/miggo-collector:v26.519.2"
+          image: "registry.miggo.io/miggo/miggo-collector:v26.522.1"
           imagePullPolicy: IfNotPresent
           args:
             - --config
@@ -102,11 +102,15 @@ spec:
               path: /health
               port: 6666
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /health
               port: 6666
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           volumeMounts:
           - name: collector-config
             mountPath: /etc/collector

--- a/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.198
+    helm.sh/chart: miggo-0.0.199
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.519.2"
+    app.kubernetes.io/version: "v26.522.1"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true

--- a/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.198
+    helm.sh/chart: miggo-0.0.199
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.519.2"
+    app.kubernetes.io/version: "v26.522.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,10 +23,10 @@ spec:
         checksum/config: 6ed877707581906ad34573544b36de695bd4e68848d208fc2a19372f691cdd49
       labels:
         component: miggo-runtime
-        helm.sh/chart: miggo-0.0.198
+        helm.sh/chart: miggo-0.0.199
         app.kubernetes.io/name: miggo-runtime
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.519.2"
+        app.kubernetes.io/version: "v26.522.1"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -39,7 +39,7 @@ spec:
         - name: miggo-runtime
           securityContext:
             privileged: true
-          image: "registry.miggo.io/miggo/miggo-runtime:v26.519.2"
+          image: "registry.miggo.io/miggo/miggo-runtime:v26.522.1"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -51,7 +51,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.198
+            - --chart-version=0.0.199
             - --disable-profiler=false
             - --enable-network-tracing=false
             - --enable-file-access-tracing=false
@@ -90,11 +90,15 @@ spec:
               path: /health
               port: 6666
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /health
               port: 6666
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           resources:
             limits:
               cpu: 500m
@@ -115,7 +119,7 @@ spec:
           - name: unix-socket
             mountPath: /tmp/grpc
         - name: profiler
-          image: "registry.miggo.io/miggo/miggo-profiler:v26.519.2"
+          image: "registry.miggo.io/miggo/miggo-profiler:v26.522.1"
           imagePullPolicy: IfNotPresent
           command:
             - /root/ebpf-profiler

--- a/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-pod-watcher-cr
   labels:
-    helm.sh/chart: miggo-0.0.198
+    helm.sh/chart: miggo-0.0.199
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.519.2"
+    app.kubernetes.io/version: "v26.522.1"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-pod-watcher-crb
   labels:
-    helm.sh/chart: miggo-0.0.198
+    helm.sh/chart: miggo-0.0.199
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.519.2"
+    app.kubernetes.io/version: "v26.522.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.198
+    helm.sh/chart: miggo-0.0.199
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.519.2"
+    app.kubernetes.io/version: "v26.522.1"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true

--- a/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.198
+    helm.sh/chart: miggo-0.0.199
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.519.2"
+    app.kubernetes.io/version: "v26.522.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,10 +23,10 @@ spec:
       annotations:
       labels:
         component: miggo-scanner
-        helm.sh/chart: miggo-0.0.198
+        helm.sh/chart: miggo-0.0.199
         app.kubernetes.io/name: miggo-scanner
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.519.2"
+        app.kubernetes.io/version: "v26.522.1"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -39,7 +39,7 @@ spec:
         - name: miggo-scanner
           securityContext:
             {}
-          image: "registry.miggo.io/miggo/miggo-scanner:v26.519.2"
+          image: "registry.miggo.io/miggo/miggo-scanner:v26.522.1"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -51,7 +51,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.198
+            - --chart-version=0.0.199
             - --queue-size=10000
             
             - --cache-flush-interval=168h
@@ -81,11 +81,15 @@ spec:
               path: /health
               port: 6666
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /health
               port: 6666
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           resources:
             limits:
               cpu: 3000m

--- a/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.198
+    helm.sh/chart: miggo-0.0.199
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.519.2"
+    app.kubernetes.io/version: "v26.522.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 automountServiceAccountToken: true

--- a/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.198
+    helm.sh/chart: miggo-0.0.199
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.519.2"
+    app.kubernetes.io/version: "v26.522.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,10 +23,10 @@ spec:
       annotations:
       labels:
         component: miggo-watch
-        helm.sh/chart: miggo-0.0.198
+        helm.sh/chart: miggo-0.0.199
         app.kubernetes.io/name: miggo-watch
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.519.2"
+        app.kubernetes.io/version: "v26.522.1"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -39,7 +39,7 @@ spec:
         - name: miggo-watch
           securityContext:
             {}
-          image: "registry.miggo.io/miggo/miggo-watch:v26.519.2"
+          image: "registry.miggo.io/miggo/miggo-watch:v26.522.1"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -51,7 +51,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.198
+            - --chart-version=0.0.199
             - --interval=1h
             - --image-tracker-interval=1h
             - --exclude=pod,replica-set
@@ -90,11 +90,15 @@ spec:
               path: /health
               port: 6666
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /health
               port: 6666
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           resources:
             limits:
               cpu: 100m

--- a/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.198
+    helm.sh/chart: miggo-0.0.199
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.519.2"
+    app.kubernetes.io/version: "v26.522.1"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true

--- a/charts/miggo/templates/miggo-collector/deployment.yaml
+++ b/charts/miggo/templates/miggo-collector/deployment.yaml
@@ -159,11 +159,15 @@ spec:
               path: /health
               port: {{ .Values.healthcheck.port }}
             periodSeconds: 10
+            timeoutSeconds: {{ coalesce .Values.miggoCollector.probes.timeoutSeconds .Values.probes.timeoutSeconds }}
+            failureThreshold: {{ coalesce .Values.miggoCollector.probes.failureThreshold .Values.probes.failureThreshold }}
           readinessProbe:
             httpGet:
               path: /health
               port: {{ .Values.healthcheck.port }}
             periodSeconds: 10
+            timeoutSeconds: {{ coalesce .Values.miggoCollector.probes.timeoutSeconds .Values.probes.timeoutSeconds }}
+            failureThreshold: {{ coalesce .Values.miggoCollector.probes.failureThreshold .Values.probes.failureThreshold }}
           volumeMounts:
           - name: collector-config
             mountPath: /etc/collector

--- a/charts/miggo/templates/miggo-runtime/daemonset.yaml
+++ b/charts/miggo/templates/miggo-runtime/daemonset.yaml
@@ -133,11 +133,15 @@ spec:
               path: /health
               port: {{ .Values.healthcheck.port }}
             periodSeconds: 10
+            timeoutSeconds: {{ coalesce .Values.miggoRuntime.probes.timeoutSeconds .Values.probes.timeoutSeconds }}
+            failureThreshold: {{ coalesce .Values.miggoRuntime.probes.failureThreshold .Values.probes.failureThreshold }}
           readinessProbe:
             httpGet:
               path: /health
               port: {{ .Values.healthcheck.port }}
             periodSeconds: 10
+            timeoutSeconds: {{ coalesce .Values.miggoRuntime.probes.timeoutSeconds .Values.probes.timeoutSeconds }}
+            failureThreshold: {{ coalesce .Values.miggoRuntime.probes.failureThreshold .Values.probes.failureThreshold }}
           resources:
             {{- toYaml .Values.miggoRuntime.resources | nindent 12 }}
           volumeMounts:
@@ -346,11 +350,15 @@ spec:
               path: /health
               port: {{ .Values.miggoRuntime.analyzer.healthcheck.port }}
             periodSeconds: 10
+            timeoutSeconds: {{ coalesce .Values.miggoRuntime.analyzer.probes.timeoutSeconds .Values.probes.timeoutSeconds }}
+            failureThreshold: {{ coalesce .Values.miggoRuntime.analyzer.probes.failureThreshold .Values.probes.failureThreshold }}
           readinessProbe:
             httpGet:
               path: /health
               port: {{ .Values.miggoRuntime.analyzer.healthcheck.port }}
             periodSeconds: 10
+            timeoutSeconds: {{ coalesce .Values.miggoRuntime.analyzer.probes.timeoutSeconds .Values.probes.timeoutSeconds }}
+            failureThreshold: {{ coalesce .Values.miggoRuntime.analyzer.probes.failureThreshold .Values.probes.failureThreshold }}
           resources:
             {{- toYaml .Values.miggoRuntime.analyzer.resources | nindent 12 }}
           securityContext:

--- a/charts/miggo/templates/miggo-scanner/deployment.yaml
+++ b/charts/miggo/templates/miggo-scanner/deployment.yaml
@@ -116,11 +116,15 @@ spec:
               path: /health
               port: {{ .Values.healthcheck.port }}
             periodSeconds: 10
+            timeoutSeconds: {{ coalesce .Values.miggoScanner.probes.timeoutSeconds .Values.probes.timeoutSeconds }}
+            failureThreshold: {{ coalesce .Values.miggoScanner.probes.failureThreshold .Values.probes.failureThreshold }}
           readinessProbe:
             httpGet:
               path: /health
               port: {{ .Values.healthcheck.port }}
             periodSeconds: 10
+            timeoutSeconds: {{ coalesce .Values.miggoScanner.probes.timeoutSeconds .Values.probes.timeoutSeconds }}
+            failureThreshold: {{ coalesce .Values.miggoScanner.probes.failureThreshold .Values.probes.failureThreshold }}
           resources:
             {{- toYaml .Values.miggoScanner.resources | nindent 12 }}
           volumeMounts:

--- a/charts/miggo/templates/miggo-watch/deployment.yaml
+++ b/charts/miggo/templates/miggo-watch/deployment.yaml
@@ -126,11 +126,15 @@ spec:
               path: /health
               port: {{ .Values.healthcheck.port }}
             periodSeconds: 10
+            timeoutSeconds: {{ coalesce .Values.miggoWatch.probes.timeoutSeconds .Values.probes.timeoutSeconds }}
+            failureThreshold: {{ coalesce .Values.miggoWatch.probes.failureThreshold .Values.probes.failureThreshold }}
           readinessProbe:
             httpGet:
               path: /health
               port: {{ .Values.healthcheck.port }}
             periodSeconds: 10
+            timeoutSeconds: {{ coalesce .Values.miggoWatch.probes.timeoutSeconds .Values.probes.timeoutSeconds }}
+            failureThreshold: {{ coalesce .Values.miggoWatch.probes.failureThreshold .Values.probes.failureThreshold }}
           resources:
             {{- toYaml .Values.miggoWatch.resources | nindent 12 }}
           volumeMounts:

--- a/charts/miggo/tests/probes/test.yaml
+++ b/charts/miggo/tests/probes/test.yaml
@@ -1,0 +1,265 @@
+suite: probe timeoutSeconds and failureThreshold tests
+
+release:
+  name: miggo
+  namespace: miggo-space
+
+templates:
+  - templates/miggo-watch/deployment.yaml
+  - templates/miggo-scanner/deployment.yaml
+  - templates/miggo-runtime/daemonset.yaml
+  - templates/miggo-runtime/fluent-bit-cm.yaml
+  - templates/miggo-collector/deployment.yaml
+  - templates/miggo-collector/collector-config-cm.yaml
+
+values:
+  - values.yaml
+
+tests:
+  # --- global defaults applied to all components ---
+
+  - it: should apply global probes defaults to miggo-watch
+    template: templates/miggo-watch/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-watch")].livenessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-watch")].livenessProbe.failureThreshold
+          value: 3
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-watch")].readinessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-watch")].readinessProbe.failureThreshold
+          value: 3
+
+  - it: should apply global probes defaults to miggo-scanner
+    template: templates/miggo-scanner/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-scanner")].livenessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-scanner")].livenessProbe.failureThreshold
+          value: 3
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-scanner")].readinessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-scanner")].readinessProbe.failureThreshold
+          value: 3
+
+  - it: should apply global probes defaults to miggo-runtime
+    template: templates/miggo-runtime/daemonset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-runtime")].livenessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-runtime")].livenessProbe.failureThreshold
+          value: 3
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-runtime")].readinessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-runtime")].readinessProbe.failureThreshold
+          value: 3
+
+  - it: should apply global probes defaults to miggo-runtime analyzer
+    template: templates/miggo-runtime/daemonset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "analyzer")].livenessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "analyzer")].livenessProbe.failureThreshold
+          value: 3
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "analyzer")].readinessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "analyzer")].readinessProbe.failureThreshold
+          value: 3
+
+  - it: should apply global probes defaults to miggo-collector
+    template: templates/miggo-collector/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-collector")].livenessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-collector")].livenessProbe.failureThreshold
+          value: 3
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-collector")].readinessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-collector")].readinessProbe.failureThreshold
+          value: 3
+
+  # --- global override takes effect across all components ---
+
+  - it: should apply custom global probes to miggo-watch
+    template: templates/miggo-watch/deployment.yaml
+    set:
+      probes.timeoutSeconds: 10
+      probes.failureThreshold: 6
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-watch")].livenessProbe.timeoutSeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-watch")].livenessProbe.failureThreshold
+          value: 6
+
+  - it: should apply custom global probes to miggo-scanner
+    template: templates/miggo-scanner/deployment.yaml
+    set:
+      probes.timeoutSeconds: 10
+      probes.failureThreshold: 6
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-scanner")].livenessProbe.timeoutSeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-scanner")].livenessProbe.failureThreshold
+          value: 6
+
+  - it: should apply custom global probes to miggo-runtime
+    template: templates/miggo-runtime/daemonset.yaml
+    set:
+      probes.timeoutSeconds: 10
+      probes.failureThreshold: 6
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-runtime")].livenessProbe.timeoutSeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-runtime")].livenessProbe.failureThreshold
+          value: 6
+
+  - it: should apply custom global probes to miggo-collector
+    template: templates/miggo-collector/deployment.yaml
+    set:
+      probes.timeoutSeconds: 10
+      probes.failureThreshold: 6
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-collector")].livenessProbe.timeoutSeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-collector")].livenessProbe.failureThreshold
+          value: 6
+
+  # --- per-component overrides ---
+
+  - it: should override probes for miggo-watch only
+    template: templates/miggo-watch/deployment.yaml
+    set:
+      miggoWatch.probes.timeoutSeconds: 15
+      miggoWatch.probes.failureThreshold: 8
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-watch")].livenessProbe.timeoutSeconds
+          value: 15
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-watch")].livenessProbe.failureThreshold
+          value: 8
+
+  - it: should override probes for miggo-scanner only
+    template: templates/miggo-scanner/deployment.yaml
+    set:
+      miggoScanner.probes.timeoutSeconds: 15
+      miggoScanner.probes.failureThreshold: 8
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-scanner")].livenessProbe.timeoutSeconds
+          value: 15
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-scanner")].livenessProbe.failureThreshold
+          value: 8
+
+  - it: should override probes for miggo-runtime only
+    template: templates/miggo-runtime/daemonset.yaml
+    set:
+      miggoRuntime.probes.timeoutSeconds: 15
+      miggoRuntime.probes.failureThreshold: 8
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-runtime")].livenessProbe.timeoutSeconds
+          value: 15
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-runtime")].livenessProbe.failureThreshold
+          value: 8
+
+  - it: should override probes for miggo-runtime analyzer only
+    template: templates/miggo-runtime/daemonset.yaml
+    set:
+      miggoRuntime.analyzer.probes.timeoutSeconds: 15
+      miggoRuntime.analyzer.probes.failureThreshold: 8
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "analyzer")].livenessProbe.timeoutSeconds
+          value: 15
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "analyzer")].livenessProbe.failureThreshold
+          value: 8
+
+  - it: should override probes for miggo-collector only
+    template: templates/miggo-collector/deployment.yaml
+    set:
+      miggoCollector.probes.timeoutSeconds: 15
+      miggoCollector.probes.failureThreshold: 8
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-collector")].livenessProbe.timeoutSeconds
+          value: 15
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-collector")].livenessProbe.failureThreshold
+          value: 8
+
+  # --- per-component override does not bleed into other components ---
+
+  - it: should not affect miggo-scanner when only miggo-watch probes are overridden
+    template: templates/miggo-scanner/deployment.yaml
+    set:
+      miggoWatch.probes.timeoutSeconds: 99
+      miggoWatch.probes.failureThreshold: 99
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-scanner")].livenessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-scanner")].livenessProbe.failureThreshold
+          value: 3
+
+  - it: should not affect miggo-runtime when only miggo-collector probes are overridden
+    template: templates/miggo-runtime/daemonset.yaml
+    set:
+      miggoCollector.probes.timeoutSeconds: 99
+      miggoCollector.probes.failureThreshold: 99
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-runtime")].livenessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-runtime")].livenessProbe.failureThreshold
+          value: 3
+
+  # --- component override takes precedence over global ---
+
+  - it: component-level probes should take precedence over global
+    template: templates/miggo-watch/deployment.yaml
+    set:
+      probes.timeoutSeconds: 5
+      probes.failureThreshold: 3
+      miggoWatch.probes.timeoutSeconds: 20
+      miggoWatch.probes.failureThreshold: 10
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-watch")].livenessProbe.timeoutSeconds
+          value: 20
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "miggo-watch")].livenessProbe.failureThreshold
+          value: 10

--- a/charts/miggo/tests/probes/values.yaml
+++ b/charts/miggo/tests/probes/values.yaml
@@ -1,0 +1,19 @@
+miggo:
+  clusterName: "probes-test"
+
+config:
+  accessKey: "d6918ba5-b727-4d51-bae5-31c2a8ba59cb98944bab-d97a-4e3a-9b22-dae633070ba9"
+
+miggoWatch:
+  enabled: true
+
+miggoScanner:
+  enabled: true
+
+miggoRuntime:
+  enabled: true
+  analyzer:
+    enabled: true
+
+miggoCollector:
+  enabled: true

--- a/charts/miggo/values.yaml
+++ b/charts/miggo/values.yaml
@@ -21,6 +21,12 @@ healthcheck:
   # -- Port number for health check endpoints
   port: 6666
 
+probes:
+  # -- Timeout seconds for liveness and readiness probes across all components
+  timeoutSeconds: 10
+  # -- Failure threshold for liveness and readiness probes across all components
+  failureThreshold: 5
+
 config:
   # -- The Kubernetes platform acronym. Allowed values are:
   # - gke: Google Kubernetes Engine
@@ -180,6 +186,12 @@ miggoWatch:
       cpu: 10m
       memory: 256Mi
 
+  probes:
+    # -- Override global probes.timeoutSeconds for miggo-watch
+    timeoutSeconds: ""
+    # -- Override global probes.failureThreshold for miggo-watch
+    failureThreshold: ""
+
 miggoScanner:
   # -- Enable Miggo Scanner component
   enabled: true
@@ -260,6 +272,12 @@ miggoScanner:
       cpu: 1000m
       memory: 2Gi
 
+  probes:
+    # -- Override global probes.timeoutSeconds for miggo-scanner
+    timeoutSeconds: ""
+    # -- Override global probes.failureThreshold for miggo-scanner
+    failureThreshold: ""
+
 miggoRuntime:
   # -- Install eBPF agent on each cluster node to provide package-level
   # reachability analysis and other runtime insights.
@@ -322,6 +340,12 @@ miggoRuntime:
     limits:
       cpu: 500m
       memory: 512Mi
+
+  probes:
+    # -- Override global probes.timeoutSeconds for miggo-runtime
+    timeoutSeconds: ""
+    # -- Override global probes.failureThreshold for miggo-runtime
+    failureThreshold: ""
 
   securityContext:
     privileged: true
@@ -461,6 +485,12 @@ miggoRuntime:
       # -- Port number for health check endpoints
       port: 6667
 
+    probes:
+      # -- Override global probes.timeoutSeconds for miggo-runtime analyzer
+      timeoutSeconds: ""
+      # -- Override global probes.failureThreshold for miggo-runtime analyzer
+      failureThreshold: ""
+
 miggoCollector:
   # -- Enable Collector component
   enabled: true
@@ -554,6 +584,12 @@ miggoCollector:
     requests:
       cpu: 10m
       memory: 200Mi
+
+  probes:
+    # -- Override global probes.timeoutSeconds for miggo-collector
+    timeoutSeconds: ""
+    # -- Override global probes.failureThreshold for miggo-collector
+    failureThreshold: ""
 
   service:
     # -- Service type

--- a/charts/miggo/values.yaml
+++ b/charts/miggo/values.yaml
@@ -21,6 +21,12 @@ healthcheck:
   # -- Port number for health check endpoints
   port: 6666
 
+probes:
+  # -- Timeout seconds for liveness and readiness probes across all components
+  timeoutSeconds: 5
+  # -- Failure threshold for liveness and readiness probes across all components
+  failureThreshold: 3
+
 config:
   # -- The Kubernetes platform acronym. Allowed values are:
   # - gke: Google Kubernetes Engine
@@ -180,6 +186,12 @@ miggoWatch:
       cpu: 10m
       memory: 256Mi
 
+  probes:
+    # -- Override global probes.timeoutSeconds for miggo-watch
+    timeoutSeconds: ""
+    # -- Override global probes.failureThreshold for miggo-watch
+    failureThreshold: ""
+
 miggoScanner:
   # -- Enable Miggo Scanner component
   enabled: true
@@ -260,6 +272,12 @@ miggoScanner:
       cpu: 1000m
       memory: 2Gi
 
+  probes:
+    # -- Override global probes.timeoutSeconds for miggo-scanner
+    timeoutSeconds: ""
+    # -- Override global probes.failureThreshold for miggo-scanner
+    failureThreshold: ""
+
 miggoRuntime:
   # -- Install eBPF agent on each cluster node to provide package-level
   # reachability analysis and other runtime insights.
@@ -322,6 +340,12 @@ miggoRuntime:
     limits:
       cpu: 500m
       memory: 512Mi
+
+  probes:
+    # -- Override global probes.timeoutSeconds for miggo-runtime
+    timeoutSeconds: ""
+    # -- Override global probes.failureThreshold for miggo-runtime
+    failureThreshold: ""
 
   securityContext:
     privileged: true
@@ -461,6 +485,12 @@ miggoRuntime:
       # -- Port number for health check endpoints
       port: 6667
 
+    probes:
+      # -- Override global probes.timeoutSeconds for miggo-runtime analyzer
+      timeoutSeconds: ""
+      # -- Override global probes.failureThreshold for miggo-runtime analyzer
+      failureThreshold: ""
+
 miggoCollector:
   # -- Enable Collector component
   enabled: true
@@ -554,6 +584,12 @@ miggoCollector:
     requests:
       cpu: 10m
       memory: 200Mi
+
+  probes:
+    # -- Override global probes.timeoutSeconds for miggo-collector
+    timeoutSeconds: ""
+    # -- Override global probes.failureThreshold for miggo-collector
+    failureThreshold: ""
 
   service:
     # -- Service type

--- a/charts/miggo/values.yaml
+++ b/charts/miggo/values.yaml
@@ -186,6 +186,12 @@ miggoWatch:
       cpu: 10m
       memory: 256Mi
 
+  probes:
+    # -- Override global probes.timeoutSeconds for miggo-watch
+    timeoutSeconds: ""
+    # -- Override global probes.failureThreshold for miggo-watch
+    failureThreshold: ""
+
 miggoScanner:
   # -- Enable Miggo Scanner component
   enabled: true
@@ -266,6 +272,12 @@ miggoScanner:
       cpu: 1000m
       memory: 2Gi
 
+  probes:
+    # -- Override global probes.timeoutSeconds for miggo-scanner
+    timeoutSeconds: ""
+    # -- Override global probes.failureThreshold for miggo-scanner
+    failureThreshold: ""
+
 miggoRuntime:
   # -- Install eBPF agent on each cluster node to provide package-level
   # reachability analysis and other runtime insights.
@@ -328,6 +340,12 @@ miggoRuntime:
     limits:
       cpu: 500m
       memory: 512Mi
+
+  probes:
+    # -- Override global probes.timeoutSeconds for miggo-runtime
+    timeoutSeconds: ""
+    # -- Override global probes.failureThreshold for miggo-runtime
+    failureThreshold: ""
 
   securityContext:
     privileged: true
@@ -467,6 +485,12 @@ miggoRuntime:
       # -- Port number for health check endpoints
       port: 6667
 
+    probes:
+      # -- Override global probes.timeoutSeconds for miggo-runtime analyzer
+      timeoutSeconds: ""
+      # -- Override global probes.failureThreshold for miggo-runtime analyzer
+      failureThreshold: ""
+
 miggoCollector:
   # -- Enable Collector component
   enabled: true
@@ -560,6 +584,12 @@ miggoCollector:
     requests:
       cpu: 10m
       memory: 200Mi
+
+  probes:
+    # -- Override global probes.timeoutSeconds for miggo-collector
+    timeoutSeconds: ""
+    # -- Override global probes.failureThreshold for miggo-collector
+    failureThreshold: ""
 
   service:
     # -- Service type


### PR DESCRIPTION
## Description

- Add global `probes.timeoutSeconds` (default: 5) and `probes.failureThreshold` (default: 3) to `values.yaml`, applied to all liveness and readiness probes across all components
- Allow per-component override via `<component>.probes.timeoutSeconds` / `<component>.probes.failureThreshold` (empty by default, falls back to global via `coalesce`) 
- Covers all 5 probe locations: miggo-watch, miggo-scanner, miggo-collector, miggo-runtime, and miggo-runtime analyzer
- Add `tests/probes/` test suite with 17 cases covering defaults, global overrides, per-component overrides, isolation between components, and precedence

## Chart Information

- **Chart Name:** `miggo`

## Type of Change

- [x] Chart version bump
- [ ] Bug fix
- [x] Feature addition
- [ ] Documentation update

## Testing

- [x] `helm lint` passes
- [x] `helm template` renders successfully
- [x] Chart installs/upgrades without issues
- [x] Tested on Kubernetes

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes (describe below)
