### PR TITLE
ci(release): append bundled-images section to chart release notes (DAQ-42)

### DIFF
--- a/.github/scripts/bundled-images-notes.sh
+++ b/.github/scripts/bundled-images-notes.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Render the chart and print a marker-wrapped markdown section listing every
+# container image the chart can deploy and its tag. Pure: no GitHub/network use,
+# so it can be run locally against any chart checkout.
+#
+# Usage: bundled-images-notes.sh [chart-dir]   (chart-dir defaults to charts/miggo)
+set -euo pipefail
+
+chart_dir="${1:-charts/miggo}"
+
+# Force-enable every component so default-disabled images render too. A new
+# default-disabled component must be added here with its own --set <c>.enabled=true.
+rendered=$(helm template "$chart_dir" \
+  --set miggoRuntime.enabled=true \
+  --set miggoRuntime.analyzer.enabled=true \
+  --set miggoRuntime.profiler.enabled=true \
+  --set miggoRuntime.fluentbit.enabled=true)
+
+images=$(echo "$rendered" | grep -oE 'image: "?[^"]+"?' | sed -E 's/^image: //; s/"//g' | sort -u)
+
+version=$(grep -E '^version:' "$chart_dir/Chart.yaml" | head -1 | sed -E 's/version:[[:space:]]*//; s/"//g')
+
+rows=""
+while IFS= read -r ref; do
+  [ -n "$ref" ] || continue
+  tag="${ref##*:}"        # after the last ':'
+  image="${ref%:*}"       # before the last ':'
+  component="${image##*/}" # repository basename
+  rows+="| ${component} | \`${image}\` | \`${tag}\` |"$'\n'
+done <<< "$images"
+
+cat <<EOF
+<!-- BUNDLED_IMAGES_START -->
+## 📦 Bundled images
+
+| Component | Image | Tag |
+|---|---|---|
+${rows}
+<sub>All images the chart can deploy, rendered from chart \`${version}\`. Whether each runs depends on your values.</sub>
+<!-- BUNDLED_IMAGES_END -->
+EOF

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,7 @@ jobs:
           version: v3.9.0
 
       - name: Run chart-releaser
+        id: release
         uses: ./.github/actions/helm-releaser
         with:
           charts_dir: charts
@@ -57,3 +58,20 @@ jobs:
         env:
           CR_TOKEN: "${{ steps.set-token.outputs.checkout_token }}"
           CR_GENERATE_RELEASE_NOTES: true
+
+      - name: Append bundled images to release notes
+        if: steps.release.outputs.changed_charts != ''
+        env:
+          GH_TOKEN: ${{ steps.set-token.outputs.checkout_token }}
+        run: |
+          version=$(grep -E '^version:' charts/miggo/Chart.yaml | head -1 | sed -E 's/version:[[:space:]]*//; s/"//g')
+          tag="miggo-${version}"
+          section=$(.github/scripts/bundled-images-notes.sh charts/miggo)
+          if ! body=$(gh release view "$tag" --json body -q .body 2>/dev/null); then
+            echo "::warning::release $tag not found, skipping bundled-images notes"
+            exit 0
+          fi
+          body="${body%%<!-- BUNDLED_IMAGES_START -->*}"
+          while [ "${body: -1}" = $'\n' ]; do body="${body%$'\n'}"; done
+          printf '%s\n\n%s\n' "$body" "$section" | gh release edit "$tag" --notes-file -
+          echo "$section" >> "$GITHUB_STEP_SUMMARY"

--- a/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
@@ -628,7 +628,7 @@ data:
                 new_value: Miggo Collector
               - action: add_label
                 new_label: chart_version
-                new_value: 0.0.206
+                new_value: 0.0.207
 
       batch/metrics:
         timeout: 10s

--- a/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.206
+    helm.sh/chart: miggo-0.0.207
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.528.1"
+    app.kubernetes.io/version: "v26.528.2"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,14 +23,14 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9db45bc361347373976c63a846620836551ccdd3231fdb6705ad3401025b7614
+        checksum/config: cd6ab8d095d2683de0f46e83075dd702c5dd7552696d61ba3b3624c6e780e615
       labels:
         component: collector
         miggo.io/app: example-collector
-        helm.sh/chart: miggo-0.0.206
+        helm.sh/chart: miggo-0.0.207
         app.kubernetes.io/name: miggo-collector
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.528.1"
+        app.kubernetes.io/version: "v26.528.2"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: example-collector
       initContainers:
         - name: collector-init-container
-          image: "registry.miggo.io/miggo/miggo-collector:v26.528.1"
+          image: "registry.miggo.io/miggo/miggo-collector:v26.528.2"
           securityContext:
             runAsGroup: 65532
             runAsNonRoot: true
@@ -79,7 +79,7 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
-          image: "registry.miggo.io/miggo/miggo-collector:v26.528.1"
+          image: "registry.miggo.io/miggo/miggo-collector:v26.528.2"
           imagePullPolicy: IfNotPresent
           args:
             - --config

--- a/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.206
+    helm.sh/chart: miggo-0.0.207
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.528.1"
+    app.kubernetes.io/version: "v26.528.2"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true

--- a/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.206
+    helm.sh/chart: miggo-0.0.207
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.528.1"
+    app.kubernetes.io/version: "v26.528.2"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,10 +23,10 @@ spec:
         checksum/config: 6ed877707581906ad34573544b36de695bd4e68848d208fc2a19372f691cdd49
       labels:
         component: miggo-runtime
-        helm.sh/chart: miggo-0.0.206
+        helm.sh/chart: miggo-0.0.207
         app.kubernetes.io/name: miggo-runtime
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.528.1"
+        app.kubernetes.io/version: "v26.528.2"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -40,7 +40,7 @@ spec:
         - name: miggo-runtime
           securityContext:
             privileged: true
-          image: "registry.miggo.io/miggo/miggo-runtime:v26.528.1"
+          image: "registry.miggo.io/miggo/miggo-runtime:v26.528.2"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -52,7 +52,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.206
+            - --chart-version=0.0.207
             - --auth-url=https://auth.miggo.io
             - --disable-profiler=false
             - --enable-network-tracing=false
@@ -121,7 +121,7 @@ spec:
           - name: unix-socket
             mountPath: /tmp/grpc
         - name: profiler
-          image: "registry.miggo.io/miggo/miggo-profiler:v26.528.1"
+          image: "registry.miggo.io/miggo/miggo-profiler:v26.528.2"
           imagePullPolicy: IfNotPresent
           command:
             - /root/ebpf-profiler

--- a/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-pod-watcher-cr
   labels:
-    helm.sh/chart: miggo-0.0.206
+    helm.sh/chart: miggo-0.0.207
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.528.1"
+    app.kubernetes.io/version: "v26.528.2"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-pod-watcher-crb
   labels:
-    helm.sh/chart: miggo-0.0.206
+    helm.sh/chart: miggo-0.0.207
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.528.1"
+    app.kubernetes.io/version: "v26.528.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.206
+    helm.sh/chart: miggo-0.0.207
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.528.1"
+    app.kubernetes.io/version: "v26.528.2"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true

--- a/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.206
+    helm.sh/chart: miggo-0.0.207
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.528.1"
+    app.kubernetes.io/version: "v26.528.2"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,10 +23,10 @@ spec:
       annotations:
       labels:
         component: miggo-scanner
-        helm.sh/chart: miggo-0.0.206
+        helm.sh/chart: miggo-0.0.207
         app.kubernetes.io/name: miggo-scanner
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.528.1"
+        app.kubernetes.io/version: "v26.528.2"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -39,7 +39,7 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
-          image: "registry.miggo.io/miggo/miggo-scanner:v26.528.1"
+          image: "registry.miggo.io/miggo/miggo-scanner:v26.528.2"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -51,7 +51,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.206
+            - --chart-version=0.0.207
             - --queue-size=10000
             
             - --cache-flush-interval=168h

--- a/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.206
+    helm.sh/chart: miggo-0.0.207
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.528.1"
+    app.kubernetes.io/version: "v26.528.2"
     app.kubernetes.io/managed-by: Helm
   annotations:
 automountServiceAccountToken: true

--- a/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.206
+    helm.sh/chart: miggo-0.0.207
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.528.1"
+    app.kubernetes.io/version: "v26.528.2"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,10 +23,10 @@ spec:
       annotations:
       labels:
         component: miggo-watch
-        helm.sh/chart: miggo-0.0.206
+        helm.sh/chart: miggo-0.0.207
         app.kubernetes.io/name: miggo-watch
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.528.1"
+        app.kubernetes.io/version: "v26.528.2"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -39,7 +39,7 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
-          image: "registry.miggo.io/miggo/miggo-watch:v26.528.1"
+          image: "registry.miggo.io/miggo/miggo-watch:v26.528.2"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -51,7 +51,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.206
+            - --chart-version=0.0.207
             - --interval=1h
             - --image-tracker-interval=1h
             - --exclude=pod,replica-set

--- a/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.206
+    helm.sh/chart: miggo-0.0.207
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.528.1"
+    app.kubernetes.io/version: "v26.528.2"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true


### PR DESCRIPTION
Resolves DAQ-42.

## Description

`chart-releaser` auto-generates release notes from the commit/PR changelog only — they never say **which images** the chart ships or at **what tags**. This appends a rendered **Bundled images** table to the GitHub Release body so every release self-documents its images.

A single step added to `.github/workflows/release.yaml` (after `Run chart-releaser`) covers **both** release paths, which funnel through this workflow:
- Direct: `release.yaml` (`workflow_dispatch` / `workflow_call`).
- Via `k8s-integrations`: `release-all.yaml` → `update-miggo-app-version.yaml` → `release.yaml@main`.

### How it works
- New `.github/scripts/bundled-images-notes.sh` (pure, locally runnable): renders the chart with all components force-enabled (`helm template … --set miggoRuntime.enabled=true …`), scrapes the rendered `image:` refs, and prints a marker-wrapped `Component | Image | Tag` table. Rendering is the source of truth, so per-component quirks stay correct (e.g. `fluent/fluent-bit:5.0` carries no registry prefix and a pinned tag).
- The workflow step reads the chart version from `Chart.yaml` (`miggo-<version>`), fetches the release body, strips any prior block between the `<!-- BUNDLED_IMAGES_* -->` markers, re-appends the fresh section, and also echoes it to the Actions run summary. Guarded on `steps.release.outputs.changed_charts != ''` so the "no chart changed → no release" path is a clean no-op. Reuses the existing app token (`contents: write`).
- Default-disabled components (`miggoRuntime`, `miggoRuntime.analyzer`) are force-enabled so **all** bundled images appear regardless of default enablement.

### Rendered example (chart `0.0.207`)
```
## 📦 Bundled images

| Component | Image | Tag |
|---|---|---|
| fluent-bit | `fluent/fluent-bit` | `5.0` |
| miggo-analyzer | `registry.miggo.io/miggo/miggo-analyzer` | `v26.528.2` |
| miggo-collector | `registry.miggo.io/miggo/miggo-collector` | `v26.528.2` |
| miggo-profiler | `registry.miggo.io/miggo/miggo-profiler` | `v26.528.2` |
| miggo-runtime | `registry.miggo.io/miggo/miggo-runtime` | `v26.528.2` |
| miggo-scanner | `registry.miggo.io/miggo/miggo-scanner` | `v26.528.2` |
| miggo-watch | `registry.miggo.io/miggo/miggo-watch` | `v26.528.2` |
```

## Chart Information

- **Chart Name:** `miggo`

## Type of Change

- [x] CI / release workflow change
- [ ] Chart version bump
- [ ] Bug fix
- [ ] Feature addition
- [ ] Documentation update

> Workflow-only change — no `charts/**` edit, so `bump-version.yaml` does not trigger and no rendered-examples regeneration is needed.

## Testing

Workflows have no unit-test harness; verified by running the render+format logic locally on the worktree:

- [x] `bash -n` + `shellcheck` clean on the new script.
- [x] **Render (happy path):** script against `charts/miggo` produces the 7 expected rows above — six miggo-owned images tracking `Chart.AppVersion`, `fluent-bit` pinned at `5.0`; caption shows chart `0.0.207`. Cross-checked against real tags `miggo-0.0.199/201/202/204/207` — tags track `appVersion` exactly.
- [x] **Idempotency:** simulated the workflow's strip-and-append across repeated runs — exactly one marker block remains, the upstream changelog is preserved, and the result is byte-stable across re-runs (trailing newlines trimmed before re-append).
- [x] **Guard:** step is skipped when no chart changed (`changed_charts == ''`) and warns-and-skips if the release isn't found.
- [ ] Tested on Kubernetes — N/A (release-notes tooling, no chart/runtime behavior change).

## Breaking Changes

- [x] No breaking changes — additive to release notes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)