### PR TITLE
mount value files to miggo watch

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -13,7 +13,7 @@ runs:
     - name: Set up Helm
       uses: azure/setup-helm@v5
       with:
-        version: v3.9.0
+        version: v4.2.0
 
     - uses: actions/setup-python@v4
       with:

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v5
         with:
-          version: v3.9.0
+          version: v4.2.0
 
       - name: Patch chart name and version for dev release
         id: version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,13 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v5
         with:
-          version: v3.9.0
+          version: v4.2.0
+
+      - name: Copy default values for chart packaging
+        # Helm excludes values.yaml from .Files, so we keep a copy in files/ that the
+        # miggo-values-defaults ConfigMap template reads via .Files.Get. This step
+        # produces it at package time so it never needs to be committed.
+        run: cp charts/miggo/values.yaml charts/miggo/files/default-values.yaml
 
       - name: Run chart-releaser
         id: release

--- a/.github/workflows/run-unittests.yaml
+++ b/.github/workflows/run-unittests.yaml
@@ -15,7 +15,9 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Set up Helm
-        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        uses: azure/setup-helm@v5
+        with:
+          version: v4.2.0
 
       - name: Install helm unittest plugin
         run: |

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,15 @@ check-examples:
 				echo "Passed $${example}"; \
 			else \
 				echo "Failed $${example}. run 'make generate-examples' to re-render the example with the latest $${example}/values.yaml"; \
+				diff -r "$${EXAMPLES_DIR}/$${example}/rendered" "${TMP_DIRECTORY}/$${example}/$${chart_name}/templates"; \
+				echo "--- committed values-original-cm.yaml ---"; \
+				cat "$${EXAMPLES_DIR}/$${example}/rendered/miggo-watch/values-original-cm.yaml" 2>/dev/null || echo "(not found)"; \
+				echo "--- generated values-original-cm.yaml ---"; \
+				cat "${TMP_DIRECTORY}/$${example}/$${chart_name}/templates/miggo-watch/values-original-cm.yaml" 2>/dev/null || echo "(not found)"; \
+				echo "--- committed values-rendered-cm.yaml ---"; \
+				cat "$${EXAMPLES_DIR}/$${example}/rendered/miggo-watch/values-rendered-cm.yaml" 2>/dev/null || echo "(not found)"; \
+				echo "--- generated values-rendered-cm.yaml ---"; \
+				cat "${TMP_DIRECTORY}/$${example}/$${chart_name}/templates/miggo-watch/values-rendered-cm.yaml" 2>/dev/null || echo "(not found)"; \
 				rm -rf ${TMP_DIRECTORY}; \
 				exit 1; \
 			fi; \

--- a/charts/miggo/.gitignore
+++ b/charts/miggo/.gitignore
@@ -1,0 +1,1 @@
+files/default-values.yaml

--- a/charts/miggo/Chart.yaml
+++ b/charts/miggo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: miggo
 description: A Helm chart for Miggo
 type: application
-version: 0.0.217
+version: 0.0.218
 appVersion: "v26.617.1"
 maintainers:
   - name: miggo-io

--- a/charts/miggo/README.md
+++ b/charts/miggo/README.md
@@ -1,6 +1,6 @@
 # Miggo Helm Chart
 
-![Version: 0.0.217](https://img.shields.io/badge/Version-0.0.217-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.617.1](https://img.shields.io/badge/AppVersion-v26.617.1-informational?style=flat-square)
+![Version: 0.0.218](https://img.shields.io/badge/Version-0.0.218-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.617.1](https://img.shields.io/badge/AppVersion-v26.617.1-informational?style=flat-square)
 
 This Helm chart deploys Miggo's components, providing comprehensive monitoring, security, and observability capabilities for your Kubernetes clusters.
 

--- a/charts/miggo/examples/default/rendered/access-key-secret.yaml
+++ b/charts/miggo/examples/default/rendered/access-key-secret.yaml
@@ -8,3 +8,4 @@ metadata:
 type: Opaque
 data:
   ACCESS_KEY: "cmVwbGFjZS13aXRoLXlvdXItYWNjZXNzLWtleQ=="
+

--- a/charts/miggo/examples/default/rendered/image-pull-secret.yaml
+++ b/charts/miggo/examples/default/rendered/image-pull-secret.yaml
@@ -8,3 +8,5 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: "eyJhdXRocyI6eyJyZWdpc3RyeS5taWdnby5pbyI6eyJ1c2VybmFtZSI6IlAyVWpzSndPRmRJZVVBdFcwcEdUSjVTZUpBbHEiLCJwYXNzd29yZCI6InJlcGxhY2Utd2l0aC15b3VyLWFjY2Vzcy1rZXkifX19"
+
+

--- a/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
@@ -628,7 +628,7 @@ data:
                 new_value: Miggo Collector
               - action: add_label
                 new_label: chart_version
-                new_value: 0.0.213
+                new_value: 0.0.218
 
       batch/metrics:
         timeout: 10s
@@ -797,3 +797,5 @@ data:
             - attributes
           exporters:
             - otlphttp
+
+

--- a/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.213
+    helm.sh/chart: miggo-0.0.218
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.610.1"
+    app.kubernetes.io/version: "v26.617.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,14 +23,14 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: aeba4893b88afbbe92ca3fffe37d043dea4f472caaf22da2577f48d028bf12ef
+        checksum/config: f3d18c8f97bcc9f7d8528c72fd15e6ca6e8fe1c80ca4b6ab62a3954b6c599a10
       labels:
         component: collector
         miggo.io/app: example-collector
-        helm.sh/chart: miggo-0.0.213
+        helm.sh/chart: miggo-0.0.218
         app.kubernetes.io/name: miggo-collector
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.610.1"
+        app.kubernetes.io/version: "v26.617.1"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: example-collector
       initContainers:
         - name: collector-init-container
-          image: "registry.miggo.io/miggo/miggo-collector:v26.610.1"
+          image: "registry.miggo.io/miggo/miggo-collector:v26.617.1"
           securityContext:
             runAsGroup: 65532
             runAsNonRoot: true
@@ -79,7 +79,7 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
-          image: "registry.miggo.io/miggo/miggo-collector:v26.610.1"
+          image: "registry.miggo.io/miggo/miggo-collector:v26.617.1"
           imagePullPolicy: IfNotPresent
           args:
             - --config
@@ -138,3 +138,5 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
+
+

--- a/charts/miggo/examples/default/rendered/miggo-collector/role.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/role.yaml
@@ -17,3 +17,6 @@ rules:
 - apiGroups: ["", "apps", "batch", "autoscaling", "coordination.k8s.io"]
   resources: ["*"]
   verbs: ["get", "list", "watch"]
+
+
+

--- a/charts/miggo/examples/default/rendered/miggo-collector/rolebinding.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/rolebinding.yaml
@@ -13,3 +13,5 @@ roleRef:
   kind: Role
   name: collector-role
   apiGroup: rbac.authorization.k8s.io
+
+

--- a/charts/miggo/examples/default/rendered/miggo-collector/service.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/service.yaml
@@ -23,3 +23,5 @@ spec:
       port: 4317
       protocol: TCP
       targetPort: 4317
+
+

--- a/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
@@ -6,9 +6,11 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.213
+    helm.sh/chart: miggo-0.0.218
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.610.1"
+    app.kubernetes.io/version: "v26.617.1"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
+
+

--- a/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.213
+    helm.sh/chart: miggo-0.0.218
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.610.1"
+    app.kubernetes.io/version: "v26.617.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,10 +23,10 @@ spec:
         checksum/config: 6ed877707581906ad34573544b36de695bd4e68848d208fc2a19372f691cdd49
       labels:
         component: miggo-runtime
-        helm.sh/chart: miggo-0.0.213
+        helm.sh/chart: miggo-0.0.218
         app.kubernetes.io/name: miggo-runtime
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.610.1"
+        app.kubernetes.io/version: "v26.617.1"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -40,7 +40,7 @@ spec:
         - name: miggo-runtime
           securityContext:
             privileged: true
-          image: "registry.miggo.io/miggo/miggo-runtime:v26.610.1"
+          image: "registry.miggo.io/miggo/miggo-runtime:v26.617.1"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -52,7 +52,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.213
+            - --chart-version=0.0.218
             - --auth-url=https://auth.miggo.io
             - --disable-profiler=false
             - --enable-network-tracing=false
@@ -121,7 +121,7 @@ spec:
           - name: unix-socket
             mountPath: /tmp/grpc
         - name: profiler
-          image: "registry.miggo.io/miggo/miggo-profiler:v26.610.1"
+          image: "registry.miggo.io/miggo/miggo-profiler:v26.617.1"
           imagePullPolicy: IfNotPresent
           command:
             - /root/ebpf-profiler
@@ -237,3 +237,5 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
+
+

--- a/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-pod-watcher-cr
   labels:
-    helm.sh/chart: miggo-0.0.213
+    helm.sh/chart: miggo-0.0.218
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.610.1"
+    app.kubernetes.io/version: "v26.617.1"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -19,3 +19,4 @@ rules:
   - get
   - watch
   - list
+

--- a/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-pod-watcher-crb
   labels:
-    helm.sh/chart: miggo-0.0.213
+    helm.sh/chart: miggo-0.0.218
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.610.1"
+    app.kubernetes.io/version: "v26.617.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -18,3 +18,4 @@ subjects:
 - kind: ServiceAccount
   name: example-runtime
   namespace: 'default'
+

--- a/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
@@ -6,9 +6,10 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.213
+    helm.sh/chart: miggo-0.0.218
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.610.1"
+    app.kubernetes.io/version: "v26.617.1"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
+

--- a/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.213
+    helm.sh/chart: miggo-0.0.218
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.610.1"
+    app.kubernetes.io/version: "v26.617.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,10 +23,10 @@ spec:
       annotations:
       labels:
         component: miggo-scanner
-        helm.sh/chart: miggo-0.0.213
+        helm.sh/chart: miggo-0.0.218
         app.kubernetes.io/name: miggo-scanner
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.610.1"
+        app.kubernetes.io/version: "v26.617.1"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -39,7 +39,7 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
-          image: "registry.miggo.io/miggo/miggo-scanner:v26.610.1"
+          image: "registry.miggo.io/miggo/miggo-scanner:v26.617.1"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -51,7 +51,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.213
+            - --chart-version=0.0.218
             - --queue-size=10000
             
             - --cache-flush-interval=168h
@@ -104,3 +104,5 @@ spec:
       
       nodeSelector:
         kubernetes.io/os: linux
+
+

--- a/charts/miggo/examples/default/rendered/miggo-scanner/role.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/role.yaml
@@ -34,3 +34,5 @@ rules:
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["create", "get", "delete", "update"]
+
+

--- a/charts/miggo/examples/default/rendered/miggo-scanner/rolebinding.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/rolebinding.yaml
@@ -27,3 +27,5 @@ roleRef:
   kind: Role
   name: miggo-scanner-role
   apiGroup: rbac.authorization.k8s.io
+
+

--- a/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
@@ -6,10 +6,12 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.213
+    helm.sh/chart: miggo-0.0.218
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.610.1"
+    app.kubernetes.io/version: "v26.617.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 automountServiceAccountToken: true
+
+

--- a/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.213
+    helm.sh/chart: miggo-0.0.218
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.610.1"
+    app.kubernetes.io/version: "v26.617.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -21,12 +21,13 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/values: 1340781c178920c063a0db3c7f46bf0f746116d7237cb3c59ddd45fc41a48c86
       labels:
         component: miggo-watch
-        helm.sh/chart: miggo-0.0.213
+        helm.sh/chart: miggo-0.0.218
         app.kubernetes.io/name: miggo-watch
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.610.1"
+        app.kubernetes.io/version: "v26.617.1"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -39,7 +40,7 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
-          image: "registry.miggo.io/miggo/miggo-watch:v26.610.1"
+          image: "registry.miggo.io/miggo/miggo-watch:v26.617.1"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -51,17 +52,15 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.213
+            - --chart-version=0.0.218
             - --interval=1h
             - --image-tracker-interval=1h
             - --exclude=pod,replica-set
             
             - --include-system-namespaces=false
             - --denied-namespaces=default
-            
-            - --api-url=https://api.miggo.io
-            - --auth-url=https://auth.miggo.io
-            
+            - --original-sensor-helm-values=/etc/miggo/values/defaults.yaml
+            - --rendered-sensor-helm-values=/etc/miggo/values/rendered.yaml
           envFrom:
           env:
             - name: MIGGO_WATCH_NODE_NAME
@@ -72,16 +71,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-          
-            - name: MIGGO_WATCH_CLIENT_ID
-              value: P2UjsJwOFdIeUAtW0pGTJ5SeJAlq
-            
-            - name: MIGGO_WATCH_ACCESS_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: access-key-secret
-                  key: ACCESS_KEY
-          
             - name: GOMEMLIMIT
               value: "204MiB"
           ports:
@@ -108,6 +97,20 @@ spec:
               cpu: 10m
               memory: 256Mi
           volumeMounts:
+          - name: miggo-values-rendered
+            mountPath: /etc/miggo/values/rendered.yaml
+            subPath: rendered.yaml
+          - name: miggo-values-defaults
+            mountPath: /etc/miggo/values/defaults.yaml
+            subPath: defaults.yaml
       volumes:
+      - name: miggo-values-rendered
+        configMap:
+          name: miggo-values-rendered
+      - name: miggo-values-defaults
+        configMap:
+          name: miggo-values-defaults
       nodeSelector:
         kubernetes.io/os: linux
+
+

--- a/charts/miggo/examples/default/rendered/miggo-watch/role.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/role.yaml
@@ -32,3 +32,4 @@ rules:
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
   verbs: ["get", "list", "watch"]
+

--- a/charts/miggo/examples/default/rendered/miggo-watch/rolebinding.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/rolebinding.yaml
@@ -12,3 +12,4 @@ roleRef:
   kind: ClusterRole
   name: miggo-watch-cluster-role
   apiGroup: rbac.authorization.k8s.io
+

--- a/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
@@ -6,9 +6,11 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.213
+    helm.sh/chart: miggo-0.0.218
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.610.1"
+    app.kubernetes.io/version: "v26.617.1"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
+
+

--- a/charts/miggo/examples/default/rendered/miggo-watch/values-original-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/values-original-cm.yaml
@@ -1,0 +1,13 @@
+---
+# Source: miggo/templates/miggo-watch/values-original-cm.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: miggo-values-defaults
+  namespace: default
+data:
+  defaults.yaml: |
+    
+    
+
+

--- a/charts/miggo/examples/default/rendered/miggo-watch/values-rendered-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/values-rendered-cm.yaml
@@ -1,0 +1,263 @@
+---
+# Source: miggo/templates/miggo-watch/values-rendered-cm.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: miggo-values-rendered
+  namespace: default
+data:
+  rendered.yaml: |
+    
+    affinity: {}
+    annotations: {}
+    config:
+      accessKey: replace-with-your-access-key
+      accessKeySecret: ""
+      apiUrl: https://api.miggo.io
+      authUrl: https://auth.miggo.io
+      clientId: P2UjsJwOFdIeUAtW0pGTJ5SeJAlq
+      collectorUrl: https://collector.miggo.io
+      includeSystemNamespaces: false
+      metrics:
+        interval: 60s
+      platform: ""
+    extraEnvs: []
+    extraEnvsFrom: []
+    healthcheck:
+      port: 6666
+    image:
+      pullPolicy: IfNotPresent
+      registry: registry.miggo.io
+    imagePullSecrets: []
+    labels: {}
+    manageSecurityContext: true
+    miggo:
+      clusterName: my-cluster
+    miggoCollector:
+      accessKeyMountLocation: /etc/miggo-access-key
+      annotations: {}
+      config:
+        internalLogVerbosity: INFO
+        logVerbosity: basic
+      enabled: true
+      extraEnvs: []
+      extraEnvsFrom: []
+      extraExporterNames: []
+      extraExporters: {}
+      extraExtensionNames: []
+      extraExtensions: {}
+      extraPipelines: {}
+      extraProcessorNames: []
+      extraProcessors: {}
+      image:
+        repository: miggo/miggo-collector
+      initContainers: []
+      instancePerNode: false
+      labels: {}
+      nodeSelector:
+        kubernetes.io/os: linux
+      podAnnotations: {}
+      podLabels: {}
+      priorityClassName: ""
+      probes:
+        failureThreshold: ""
+        timeoutSeconds: ""
+      replicas: 1
+      resources:
+        limits:
+          cpu: 100m
+          memory: 500Mi
+        requests:
+          cpu: 10m
+          memory: 200Mi
+      service:
+        annotations: {}
+        labels: {}
+        ports:
+        - name: http
+          port: 4318
+          protocol: TCP
+          targetPort: 4318
+        - name: grpc
+          port: 4317
+          protocol: TCP
+          targetPort: 4317
+        type: ClusterIP
+      useGOMEMLIMIT: true
+      volumeMounts: []
+      volumes: []
+    miggoRuntime:
+      affinity: {}
+      cgroupRegistryCleanInterval: 1h
+      cgroupRegistrySyncInterval: 1m
+      enableFileAccessTracing: false
+      enableNetworkTracing: false
+      enableWebAppProcessDetection: true
+      enabled: true
+      extraEnvs: []
+      extraEnvsFrom: []
+      fluentbit:
+        enabled: true
+        image:
+          repository: fluent/fluent-bit
+          tag: "5.0"
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 50m
+            memory: 50Mi
+      hostIPC: true
+      hostPID: true
+      image:
+        repository: miggo/miggo-runtime
+      kubernetesClusterDomain: ""
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: ""
+      probes:
+        failureThreshold: ""
+        timeoutSeconds: ""
+      profiler:
+        dotnet: {}
+        enableNamespaceFiltering: true
+        enabled: true
+        enabledTracers:
+        - perl
+        - php
+        - python
+        - hotspot
+        - v8
+        - go
+        image:
+          repository: miggo/miggo-profiler
+        monitorInterval: 5s
+        probabilisticInterval: 1m0s
+        probabilisticThreshold: 100
+        reporterInterval: 5s
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 200m
+            memory: 512Mi
+        samplesPerSecond: 20
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+          privileged: true
+        useGOMEMLIMIT: true
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      tolerations: []
+      useGOMEMLIMIT: true
+      volumeMounts: []
+      volumes: []
+    miggoScanner:
+      annotations: {}
+      config:
+        cache:
+          configMap:
+            enabled: true
+            name: ""
+          flushInterval: 168h
+          maxEntries: 10000
+        disableCompression: false
+        queueSize: 10000
+      enabled: true
+      extraEnvs: []
+      extraEnvsFrom: []
+      image:
+        repository: miggo/miggo-scanner
+      imagePullSecretScanning:
+        enabled: true
+      labels: {}
+      nodeSelector:
+        kubernetes.io/os: linux
+      podAnnotations: {}
+      podLabels: {}
+      probes:
+        failureThreshold: ""
+        timeoutSeconds: ""
+      registryCredentials:
+        secretName: ""
+      resources:
+        limits:
+          cpu: 3000m
+          memory: 4Gi
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+      serviceAccount:
+        annotations: {}
+      useGOMEMLIMIT: true
+      volumeMounts: []
+      volumes: []
+    miggoWatch:
+      annotations: {}
+      config:
+        disableCompression: false
+        exclude: pod,replica-set
+        imageTrackerInterval: 1h
+        interval: 1h
+      enabled: true
+      extraEnvs: []
+      extraEnvsFrom: []
+      image:
+        repository: miggo/miggo-watch
+      labels: {}
+      nodeSelector:
+        kubernetes.io/os: linux
+      podAnnotations: {}
+      podLabels: {}
+      probes:
+        failureThreshold: ""
+        timeoutSeconds: ""
+      resources:
+        limits:
+          cpu: 100m
+          memory: 256Mi
+        requests:
+          cpu: 10m
+          memory: 256Mi
+      useGOMEMLIMIT: true
+      volumeMounts: []
+      volumes: []
+    namespaceOverride: ""
+    nodeSelector: {}
+    output:
+      api:
+        apiEndpoint: ""
+        enabled: true
+      otlp:
+        otlpEndpoint: ""
+        tlsSkipVerify: false
+      stdout: false
+    podAnnotations: {}
+    podLabels: {}
+    podSecurityContext: {}
+    priorityClassName: ""
+    probes:
+      failureThreshold: 5
+      timeoutSeconds: 10
+    securityContext: {}
+    serviceAccount:
+      annotations: {}
+      automount: true
+      name: ""
+    tolerations: []
+    volumeMounts: []
+    volumes: []
+
+

--- a/charts/miggo/templates/miggo-watch/deployment.yaml
+++ b/charts/miggo/templates/miggo-watch/deployment.yaml
@@ -27,6 +27,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/values: {{ .Values | toYaml | sha256sum }}
         {{- with .Values.podAnnotations }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
@@ -83,6 +84,8 @@ spec:
             - --disable-compression
             {{ end }}
             {{- include "namespace.flags" . | nindent 12 }}
+            - --original-sensor-helm-values=/etc/miggo/values/defaults.yaml
+            - --rendered-sensor-helm-values=/etc/miggo/values/rendered.yaml
           envFrom:
           {{- with .Values.extraEnvsFrom }}
           {{- toYaml . | nindent 10 }}
@@ -128,6 +131,12 @@ spec:
           resources:
             {{- toYaml .Values.miggoWatch.resources | nindent 12 }}
           volumeMounts:
+          - name: miggo-values-rendered
+            mountPath: /etc/miggo/values/rendered.yaml
+            subPath: rendered.yaml
+          - name: miggo-values-defaults
+            mountPath: /etc/miggo/values/defaults.yaml
+            subPath: defaults.yaml
           {{- with .Values.volumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
@@ -135,6 +144,12 @@ spec:
           {{- toYaml . | nindent 10 }}
           {{- end }}
       volumes:
+      - name: miggo-values-rendered
+        configMap:
+          name: miggo-values-rendered
+      - name: miggo-values-defaults
+        configMap:
+          name: miggo-values-defaults
       {{- with .Values.volumes }}
       {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/miggo/templates/miggo-watch/values-original-cm.yaml
+++ b/charts/miggo/templates/miggo-watch/values-original-cm.yaml
@@ -1,0 +1,10 @@
+{{ if .Values.miggoWatch.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: miggo-values-defaults
+  namespace: {{ include "miggo.namespace" . }}
+data:
+  defaults.yaml: |
+    {{ .Files.Get "files/default-values.yaml" | nindent 4 }}
+{{ end }}

--- a/charts/miggo/templates/miggo-watch/values-rendered-cm.yaml
+++ b/charts/miggo/templates/miggo-watch/values-rendered-cm.yaml
@@ -1,0 +1,10 @@
+{{ if .Values.miggoWatch.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: miggo-values-rendered
+  namespace: {{ include "miggo.namespace" . }}
+data:
+  rendered.yaml: |
+    {{ .Values | toYaml | nindent 4 }}
+{{ end }}

--- a/charts/miggo/tests/endpoints/test.yaml
+++ b/charts/miggo/tests/endpoints/test.yaml
@@ -56,20 +56,6 @@ tests:
             name: AUTH_BASE_URL
             value: https://auth.miggo.io
 
-  - it: should pass config.apiUrl to miggo-watch via --api-url
-    template: templates/miggo-watch/deployment.yaml
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[?(@.name == "miggo-watch")].args
-          content: --api-url=https://api.miggo.io
-
-  - it: should pass config.authUrl to miggo-watch via --auth-url
-    template: templates/miggo-watch/deployment.yaml
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[?(@.name == "miggo-watch")].args
-          content: --auth-url=https://auth.miggo.io
-
   - it: should pass config.authUrl to the miggo-runtime container via --auth-url (authenticates without an api URL)
     template: templates/miggo-runtime/daemonset.yaml
     asserts:
@@ -121,26 +107,6 @@ tests:
           content:
             name: API_HEALTH_URL
             value: https://my-api.example.com/health/status
-
-  - it: should propagate custom config.apiUrl to miggo-watch --api-url
-    template: templates/miggo-watch/deployment.yaml
-    set:
-      config:
-        apiUrl: https://my-api.example.com
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[?(@.name == "miggo-watch")].args
-          content: --api-url=https://my-api.example.com
-
-  - it: should propagate custom config.authUrl to miggo-watch --auth-url
-    template: templates/miggo-watch/deployment.yaml
-    set:
-      config:
-        authUrl: https://my-auth.example.com
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[?(@.name == "miggo-watch")].args
-          content: --auth-url=https://my-auth.example.com
 
   - it: should propagate custom config.authUrl to the miggo-runtime container --auth-url
     template: templates/miggo-runtime/daemonset.yaml
@@ -227,15 +193,3 @@ tests:
             name: API_HEALTH_URL
             value: https://custom-collector.example.com/health/status
 
-  - it: should NOT leak custom config.collectorUrl into miggo-watch --api-url
-    template: templates/miggo-watch/deployment.yaml
-    set:
-      config:
-        collectorUrl: https://custom-collector.example.com
-      output:
-        api:
-          apiEndpoint: ""
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[?(@.name == "miggo-watch")].args
-          content: --api-url=https://api.miggo.io


### PR DESCRIPTION
## Description

Adds the Helm chart side of the customer-values feature: a `values-cm.yaml` template renders the rendered/default values into two ConfigMaps mounted into Miggo Watch, plus a CI step to snapshot values.yaml into files/ at package time so `.Files.Get` can read it.

## Chart Information

- **Chart Name:** `miggo`

## Type of Change

- [x] Chart version bump
- [ ] Bug fix
- [x] Feature addition
- [ ] Documentation update

## Testing

- [x] `helm lint` passes
- [x] `helm template` renders successfully
- [x] Chart installs/upgrades without issues
- [x] Tested on Kubernetes

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes (describe below)
