### PR TITLE
chore(miggo-watch): remove backend-API args and auth env (DAQ-50)

### DIFF
--- a/charts/miggo/Chart.yaml
+++ b/charts/miggo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: miggo
 description: A Helm chart for Miggo
 type: application
-version: 0.0.216
+version: 0.0.217
 appVersion: "v26.617.1"
 maintainers:
   - name: miggo-io

--- a/charts/miggo/README.md
+++ b/charts/miggo/README.md
@@ -1,6 +1,6 @@
 # Miggo Helm Chart
 
-![Version: 0.0.216](https://img.shields.io/badge/Version-0.0.216-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.617.1](https://img.shields.io/badge/AppVersion-v26.617.1-informational?style=flat-square)
+![Version: 0.0.217](https://img.shields.io/badge/Version-0.0.217-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.617.1](https://img.shields.io/badge/AppVersion-v26.617.1-informational?style=flat-square)
 
 This Helm chart deploys Miggo's components, providing comprehensive monitoring, security, and observability capabilities for your Kubernetes clusters.
 

--- a/charts/miggo/templates/miggo-watch/deployment.yaml
+++ b/charts/miggo/templates/miggo-watch/deployment.yaml
@@ -83,10 +83,6 @@ spec:
             - --disable-compression
             {{ end }}
             {{- include "namespace.flags" . | nindent 12 }}
-            {{ if .Values.output.api.enabled }}
-            - --api-url={{ (include "apiEndpoint" . )}}
-            - --auth-url={{ .Values.config.authUrl }}
-            {{ end }}
           envFrom:
           {{- with .Values.extraEnvsFrom }}
           {{- toYaml . | nindent 10 }}
@@ -103,17 +99,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-          {{ if .Values.output.api.enabled }}
-            - name: MIGGO_WATCH_CLIENT_ID
-              value: {{ .Values.config.clientId }}
-            {{ if (include "accessKeySecret" .) }}
-            - name: MIGGO_WATCH_ACCESS_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "accessKeySecret" . }}
-                  key: ACCESS_KEY
-            {{- end }}
-          {{ end }}
           {{- if and (.Values.miggoWatch.useGOMEMLIMIT) ((((.Values.miggoWatch.resources).limits).memory))  }}
             - name: GOMEMLIMIT
               value: {{ include "gomemlimit" .Values.miggoWatch.resources.limits.memory | quote }}


### PR DESCRIPTION
Part of DAQ-50 (deprecating the Miggo Backend API + redundant auth from the sensor).

## TL;DR
miggo-watch no longer calls the Miggo backend API — it emits OTLP only, and the SaaS collector handles tenant/project attribution. This removes the now-dead backend-API wiring from the miggo-watch Deployment.

## Changes
`charts/miggo/templates/miggo-watch/deployment.yaml` — remove the two `{{ if .Values.output.api.enabled }}` blocks:
- args: `--api-url` + `--auth-url`
- env: `MIGGO_WATCH_CLIENT_ID` + `MIGGO_WATCH_ACCESS_TOKEN`

Collector-side auth is untouched (oauth2client extension, init script, the access-key secret definition). `values.yaml`, `output.api`/`apiEndpoint`, and the `apiUrl` helper are left in place — still used by the collector.

## Test plan
- `helm lint` — pass.
- `helm template` before/after diff: the **only** change is the miggo-watch Deployment losing those four entries; miggo-collector / miggo-scanner / miggo-runtime manifests are byte-identical.

## Merge order
Merge **this PR first**, before the companion code PR (miggo-io/k8s-integrations#594). De-wiring the chart cleanly disables the old binary's API client (`Enabled()` is `baseURL != ""`); merging the code PR first would risk a cobra "unknown flag" crash while the chart still passes `--api-url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)