### PR TITLE
chore(miggo-runtime): remove backend-API args and auth env (DAQ-50)

### DIFF
--- a/charts/miggo/Chart.yaml
+++ b/charts/miggo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: miggo
 description: A Helm chart for Miggo
 type: application
-version: 0.0.217
+version: 0.0.218
 appVersion: "v26.617.1"
 maintainers:
   - name: miggo-io

--- a/charts/miggo/README.md
+++ b/charts/miggo/README.md
@@ -1,6 +1,6 @@
 # Miggo Helm Chart
 
-![Version: 0.0.217](https://img.shields.io/badge/Version-0.0.217-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.617.1](https://img.shields.io/badge/AppVersion-v26.617.1-informational?style=flat-square)
+![Version: 0.0.218](https://img.shields.io/badge/Version-0.0.218-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.617.1](https://img.shields.io/badge/AppVersion-v26.617.1-informational?style=flat-square)
 
 This Helm chart deploys Miggo's components, providing comprehensive monitoring, security, and observability capabilities for your Kubernetes clusters.
 

--- a/charts/miggo/templates/miggo-runtime/daemonset.yaml
+++ b/charts/miggo/templates/miggo-runtime/daemonset.yaml
@@ -76,7 +76,6 @@ spec:
             - --metric-tls-skip-verify={{ (include "otlpTlsSkipVerify" .) }}
             - --metric-interval={{ .Values.config.metrics.interval }}
             - --chart-version={{ .Chart.Version }}
-            - --auth-url={{ .Values.config.authUrl }}
             - --disable-profiler={{ not .Values.miggoRuntime.profiler.enabled }}
             - --enable-network-tracing={{ .Values.miggoRuntime.enableNetworkTracing }}
             - --enable-file-access-tracing={{ .Values.miggoRuntime.enableFileAccessTracing }}
@@ -112,15 +111,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          - name: MIGGO_RUNTIME_CLIENT_ID
-            value: {{ .Values.config.clientId }}
-          {{ if (include "accessKeySecret" .) }}
-          - name: MIGGO_RUNTIME_ACCESS_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "accessKeySecret" . }}
-                key: ACCESS_KEY
-          {{- end }}
           - name: KUBERNETES_CLUSTER_DOMAIN
             value: {{ quote .Values.kubernetesClusterDomain }}
           {{- with .Values.extraEnvs }}


### PR DESCRIPTION
Part of DAQ-50 (deprecating the Miggo Backend API + redundant auth from the sensor).

## TL;DR
miggo-runtime (dynamic-ebpf) no longer calls the Miggo backend API — the SaaS collector enriches tenant/project on the resource. This removes the now-dead backend-API wiring from the runtime ebpf container.

## Changes
`charts/miggo/templates/miggo-runtime/daemonset.yaml` (miggo-runtime/ebpf container): remove the `--auth-url` arg and the `MIGGO_RUNTIME_CLIENT_ID` + `MIGGO_RUNTIME_ACCESS_TOKEN` env. Collector-side auth (oauth2client, init script, access-key secret) and `--cluster-name` untouched.

## Test plan
- `helm lint` — pass.
- `helm template` (with `miggoRuntime.enabled=true`) before/after diff: the **only** change is the miggo-runtime container losing `--auth-url`/`CLIENT_ID`/`ACCESS_TOKEN`; collector/scanner/watch manifests unchanged.

## ⚠️ Rollout ordering
Pairs with the code PRs: miggo-io/k8s-integrations#596 (dynamic-ebpf) and miggo-io/miggo-profiler#103 (profiler). Because removing `--auth-url` would crash an old binary (and removing the flag would crash on old args), the **new ebpf image + this de-wired template must ship in the same chart release**. The new profiler image (more permissive — no longer requires tenant/project) must not lag behind the new ebpf image, or samples would be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)