### PR TITLE
fix(collector): correct heartbeat metric name after otelcol rename

### DIFF
--- a/charts/miggo/Chart.yaml
+++ b/charts/miggo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: miggo
 description: A Helm chart for Miggo
 type: application
-version: 0.0.219
+version: 0.0.220
 appVersion: "v26.617.1"
 maintainers:
   - name: miggo-io

--- a/charts/miggo/README.md
+++ b/charts/miggo/README.md
@@ -1,6 +1,6 @@
 # Miggo Helm Chart
 
-![Version: 0.0.219](https://img.shields.io/badge/Version-0.0.219-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.617.1](https://img.shields.io/badge/AppVersion-v26.617.1-informational?style=flat-square)
+![Version: 0.0.220](https://img.shields.io/badge/Version-0.0.220-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.617.1](https://img.shields.io/badge/AppVersion-v26.617.1-informational?style=flat-square)
 
 This Helm chart deploys Miggo's components, providing comprehensive monitoring, security, and observability capabilities for your Kubernetes clusters.
 

--- a/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
@@ -428,7 +428,7 @@ data:
                 new_value: Miggo Collector
               - action: add_label
                 new_label: chart_version
-                new_value: 0.0.219
+                new_value: 0.0.220
 
       batch/metrics:
         timeout: 10s

--- a/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
@@ -415,9 +415,6 @@ data:
     processors:
       metricstransform:
         transforms:
-          # Heartbeat source: otelcol's internal uptime metric, exposed as
-          # otelcol_process_uptime and relabeled to miggocol_process_uptime.
-          # Re-verify this name when bumping the collector — otelcol may rename it.
           - include: miggocol_process_uptime
             match_type: strict
             new_name: miggo_component_status

--- a/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
@@ -415,7 +415,10 @@ data:
     processors:
       metricstransform:
         transforms:
-          - include: miggocol_process_uptime_seconds_total
+          # Heartbeat source: otelcol's internal uptime metric, exposed as
+          # otelcol_process_uptime and relabeled to miggocol_process_uptime.
+          # Re-verify this name when bumping the collector — otelcol may rename it.
+          - include: miggocol_process_uptime
             match_type: strict
             new_name: miggo_component_status
             action: combine

--- a/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4df9790ff7f58f84c71760c439b053a7c52e13007e93babbfab30dc80c732dc6
+        checksum/config: 38145ab4e44814895cd60231a434988fefe16fe5123e64daef2a9fddb015efed
       labels:
         component: collector
         miggo.io/app: example-collector

--- a/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4f06e93d093ad6a4f5ca4629801b39d42d21305c9439dc04e7989060c76391e2
+        checksum/config: 1de8c48c3e2d211ac2b3b4111a5e6707206476b14c83986e722cc4ba224c0523
       labels:
         component: collector
         miggo.io/app: example-collector

--- a/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.219
+    helm.sh/chart: miggo-0.0.220
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.617.1"
@@ -23,11 +23,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 38145ab4e44814895cd60231a434988fefe16fe5123e64daef2a9fddb015efed
+        checksum/config: 4f06e93d093ad6a4f5ca4629801b39d42d21305c9439dc04e7989060c76391e2
       labels:
         component: collector
         miggo.io/app: example-collector
-        helm.sh/chart: miggo-0.0.219
+        helm.sh/chart: miggo-0.0.220
         app.kubernetes.io/name: miggo-collector
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v26.617.1"

--- a/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.219
+    helm.sh/chart: miggo-0.0.220
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.617.1"

--- a/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.219
+    helm.sh/chart: miggo-0.0.220
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.617.1"
@@ -23,7 +23,7 @@ spec:
         checksum/config: 6ed877707581906ad34573544b36de695bd4e68848d208fc2a19372f691cdd49
       labels:
         component: miggo-runtime
-        helm.sh/chart: miggo-0.0.219
+        helm.sh/chart: miggo-0.0.220
         app.kubernetes.io/name: miggo-runtime
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v26.617.1"
@@ -52,7 +52,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.219
+            - --chart-version=0.0.220
             - --disable-profiler=false
             - --enable-network-tracing=false
             - --enable-file-access-tracing=false

--- a/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-pod-watcher-cr
   labels:
-    helm.sh/chart: miggo-0.0.219
+    helm.sh/chart: miggo-0.0.220
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.617.1"

--- a/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-pod-watcher-crb
   labels:
-    helm.sh/chart: miggo-0.0.219
+    helm.sh/chart: miggo-0.0.220
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.617.1"

--- a/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.219
+    helm.sh/chart: miggo-0.0.220
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.617.1"

--- a/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.219
+    helm.sh/chart: miggo-0.0.220
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.617.1"
@@ -23,7 +23,7 @@ spec:
       annotations:
       labels:
         component: miggo-scanner
-        helm.sh/chart: miggo-0.0.219
+        helm.sh/chart: miggo-0.0.220
         app.kubernetes.io/name: miggo-scanner
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v26.617.1"
@@ -51,7 +51,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.219
+            - --chart-version=0.0.220
             - --queue-size=10000
             
             - --cache-flush-interval=168h

--- a/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.219
+    helm.sh/chart: miggo-0.0.220
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.617.1"

--- a/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.219
+    helm.sh/chart: miggo-0.0.220
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.617.1"
@@ -24,7 +24,7 @@ spec:
         checksum/values: 1340781c178920c063a0db3c7f46bf0f746116d7237cb3c59ddd45fc41a48c86
       labels:
         component: miggo-watch
-        helm.sh/chart: miggo-0.0.219
+        helm.sh/chart: miggo-0.0.220
         app.kubernetes.io/name: miggo-watch
         app.kubernetes.io/instance: example
         app.kubernetes.io/version: "v26.617.1"
@@ -52,7 +52,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.219
+            - --chart-version=0.0.220
             - --interval=1h
             - --image-tracker-interval=1h
             - --exclude=pod,replica-set

--- a/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.219
+    helm.sh/chart: miggo-0.0.220
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "v26.617.1"

--- a/charts/miggo/templates/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/templates/miggo-collector/collector-config-cm.yaml
@@ -74,9 +74,6 @@ data:
     processors:
       metricstransform:
         transforms:
-          # Heartbeat source: otelcol's internal uptime metric, exposed as
-          # otelcol_process_uptime and relabeled to miggocol_process_uptime.
-          # Re-verify this name when bumping the collector — otelcol may rename it.
           - include: miggocol_process_uptime
             match_type: strict
             new_name: miggo_component_status

--- a/charts/miggo/templates/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/templates/miggo-collector/collector-config-cm.yaml
@@ -74,7 +74,10 @@ data:
     processors:
       metricstransform:
         transforms:
-          - include: miggocol_process_uptime_seconds_total
+          # Heartbeat source: otelcol's internal uptime metric, exposed as
+          # otelcol_process_uptime and relabeled to miggocol_process_uptime.
+          # Re-verify this name when bumping the collector — otelcol may rename it.
+          - include: miggocol_process_uptime
             match_type: strict
             new_name: miggo_component_status
             action: combine


### PR DESCRIPTION
## TL;DR
The collector's "last seen" heartbeat stopped updating in the sensors tab for any sensor on chart **≥ 0.0.214** (OTel Collector v0.151+). One-line fix: point the heartbeat `metricstransform` at the current internal metric name.

## Root cause
The collector heartbeat `miggo_component_status{component="Miggo Collector"}` is synthesized by `metricstransform` from otelcol's internal uptime metric. The OTel Collector upgrade in chart 0.0.214 (`v0.151`, k8s-integrations #579 / SEN-425) **renamed** that metric: `:8888` now exposes `otelcol_process_uptime` (no `_seconds_total`), which the chart relabels to `miggocol_process_uptime`. The transform still keyed on `miggocol_process_uptime_seconds_total`, so it matched nothing → the heartbeat was never produced → the collector goes stale in the sensors tab while the Go components (separate heartbeat path) keep reporting.

## Evidence
- Sensors-tab `public.sensor` row for "Miggo Collector" stale exactly at the 0.0.211→0.0.214 bump; components fresh.
- Verified live on a prod collector: `:8888` → `otelcol_process_uptime` (counter); `:8889` → `miggocol_process_uptime`; **no** `miggo_component_status{component="Miggo Collector"}` produced.
- VM has `miggocol_process_uptime`, not `..._seconds_total`.

## Change
`collector-config-cm.yaml`: `metricstransform` include `miggocol_process_uptime_seconds_total` → `miggocol_process_uptime` (+ a note to re-verify on collector bumps). Regenerated rendered examples.

## Test plan
- `helm lint` ✓; `helm unittest` 122/122 ✓; `make check-examples` ✓ (regenerated with helm v4.2.0, matching CI).

## Scope
Fleet-wide latent bug since 0.0.214 — affects every sensor on the upgraded collector. Independent of the DAQ-50 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)