### PR TITLE
feat: add standalone miggo-ontime sensor component

### DIFF
--- a/charts/miggo/Chart.yaml
+++ b/charts/miggo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: miggo
 description: A Helm chart for Miggo
 type: application
-version: 0.0.223
+version: 0.0.224
 appVersion: "v26.624.3"
 maintainers:
   - name: miggo-io

--- a/charts/miggo/README.md
+++ b/charts/miggo/README.md
@@ -1,6 +1,6 @@
 # Miggo Helm Chart
 
-![Version: 0.0.223](https://img.shields.io/badge/Version-0.0.223-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.624.3](https://img.shields.io/badge/AppVersion-v26.624.3-informational?style=flat-square)
+![Version: 0.0.224](https://img.shields.io/badge/Version-0.0.224-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.624.3](https://img.shields.io/badge/AppVersion-v26.624.3-informational?style=flat-square)
 
 This Helm chart deploys Miggo's components, providing comprehensive monitoring, security, and observability capabilities for your Kubernetes clusters.
 
@@ -131,6 +131,35 @@ The following table lists the configurable parameters of the miggo chart and the
 | miggoCollector.useGOMEMLIMIT | bool | `true` | When enabled, the chart will set the GOMEMLIMIT env var to 80% of the configured resources.limits.memory. If no resources.limits.memory are defined then enabling does nothing. It is HIGHLY recommend to enable this setting and set a value for resources.limits.memory. |
 | miggoCollector.volumeMounts | list | `[]` | Additional volume mounts |
 | miggoCollector.volumes | list | `[]` | Additional volumes |
+| miggoOntime.affinity | object | `{}` | Affinity settings for the miggo-ontime DaemonSet. Global affinity specified in .Values.affinity will be merged with this configuration. |
+| miggoOntime.configOverrides | object | `{}` | Free-form map deep-merged over the chart's rendered OnTime config. Use it to tune any field not exposed as a first-class value above — intervals, caches, internal-only features (inference / firewall / pipeline / retainer / github) and their feature_options, extra sinks, per-event options, etc. Lists replace, maps merge. The chart always re-asserts the otel sink endpoint, so overriding it has no effect. See docs/miggo-ontime.md for worked examples. |
+| miggoOntime.enabled | bool | `false` | Install the OnTime runtime detection agent on each cluster node. OnTime runs in parallel to the Runtime and Profiler and submits detection events to the Collector. It depends only on the Collector, not on miggoRuntime, so it is gated independently. |
+| miggoOntime.events | list | `["cloud_meta_probe"]` | Detection recipes (events) to enable. Mirrors the OnTime standalone config catalog, grouped by detection method; everything is commented out except the single POC detection (cloud_meta_probe). Uncomment entries to enable more — OnTime has no compile-time block list, so any listed recipe is enabled. net_flow / fw_drop are telemetry (not detections) and stay off by default. |
+| miggoOntime.extraArgs | object | `{}` | Additional command-line arguments (e.g. network-flows, report). OnTime is configured via the config file; these are extra flags only. |
+| miggoOntime.extraEnvs | list | `[]` | Additional environment variables |
+| miggoOntime.extraEnvsFrom | list | `[]` | Additional environment variables from sources |
+| miggoOntime.features | list | `["hold","procfs","detect","detections","enricher"]` | OnTime features to enable (see the OnTime config reference) |
+| miggoOntime.health.enabled | bool | `true` | Run OnTime's internal health server and add an exec liveness/readiness probe that checks it. The server binds 127.0.0.1:8082 (localhost only), so the probe is an in-container `wget` exec rather than httpGet — once miggo-ontime can bind the health server externally, this becomes a plain httpGet. Probe timeouts and thresholds come from the global .Values.probes. |
+| miggoOntime.hostIPC | bool | `true` | Use the host's ipc namespace. |
+| miggoOntime.hostPID | bool | `true` | Use the host's pid namespace. |
+| miggoOntime.image.fullPath | string | `nil` | Optional full image path override. If set, takes precedence over registry/repository/tag settings. Useful for local development with Minikube or when needing to specify a complete custom image path |
+| miggoOntime.image.pullPolicy | string | `nil` | Image pull policy. Specifies when Kubernetes should pull the container image |
+| miggoOntime.image.repository | string | `"miggo/miggo-ontime"` | Image repository |
+| miggoOntime.image.tag | string | `nil` | Image tag. Defaults to "latest" — OnTime releases on its own version line (v0.0.x), independent of the chart appVersion. Pin to a specific tag for production. |
+| miggoOntime.logLevel | string | `"info"` | OnTime log level: info, debug, warn, error |
+| miggoOntime.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector settings |
+| miggoOntime.otel.eventsPerSec | object | `{"fw_drop":100,"net_flow":500}` | Per-second caps for high-frequency observation events |
+| miggoOntime.otel.serviceName | string | `"miggo-ontime"` | service.name attribute on emitted OTel records |
+| miggoOntime.priorityClassName | string | `""` | Priority class name (defaults to global priorityClassName or system-node-critical) |
+| miggoOntime.resources.limits.cpu | string | `"1"` |  |
+| miggoOntime.resources.limits.memory | string | `"1Gi"` |  |
+| miggoOntime.resources.requests.cpu | string | `"500m"` |  |
+| miggoOntime.resources.requests.memory | string | `"512Mi"` |  |
+| miggoOntime.securityContext.privileged | bool | `true` |  |
+| miggoOntime.stdout | bool | `false` | Also send events to stdout (alongside the otel sink) for debugging. |
+| miggoOntime.tolerations | list | `[]` | Tolerations for the miggo-ontime DaemonSet. Global tolerations specified in .Values.tolerations will be merged with this list. |
+| miggoOntime.volumeMounts | list | `[]` | Additional volume mounts for all containers |
+| miggoOntime.volumes | list | `[]` | Additional volumes |
 | miggoRuntime.affinity | object | `{}` | Affinity settings for the miggo-runtime DaemonSet. Global affinity specified in .Values.affinity will be merged with this configuration. |
 | miggoRuntime.cgroupRegistryCleanInterval | string | `"1h"` | Interval between sweeps to remove cgroups whose paths no longer exist on the filesystem |
 | miggoRuntime.cgroupRegistrySyncInterval | string | `"1m"` | Interval between full cgroup state syncs from the Runtime to the Profiler |

--- a/charts/miggo/docs/miggo-ontime.md
+++ b/charts/miggo/docs/miggo-ontime.md
@@ -1,0 +1,142 @@
+# MiggoOnTime — chart configuration
+
+MiggoOnTime is a standalone runtime-detection DaemonSet (gated by `miggoOntime.enabled`,
+default `false`). It depends only on the Collector, so it is configured and lifecycled
+independently of `miggoRuntime`.
+
+## How the OnTime config is produced
+
+OnTime is configured by a YAML file passed as `ontime --config /etc/ontime/config.yaml`.
+The chart builds that file in three steps:
+
+1. **Base config** — assembled from the curated `miggoOntime.*` values (log level,
+   features, events, otel service name / rates) plus fixed structural defaults
+   (intervals, caches, functionalities, `feature_options.detections`). See
+   `templates/miggo-ontime/_helpers.tpl` → `miggoOntime.baseConfig`.
+2. **Overrides** — `miggoOntime.configOverrides` is **deep-merged** over the base.
+3. **Endpoint re-assert** — the chart always sets the `otel` sink endpoint to the
+   in-cluster Collector (OTLP gRPC `:4317`). Overriding it has no effect.
+
+Merge semantics (Helm `mergeOverwrite`): **maps merge recursively, lists replace
+wholesale.** So overriding `intervals` changes only the keys you set; overriding
+`events` or `features` replaces the entire list.
+
+> ⚠️ OnTime decodes the config with strict unknown-field checking — a typo'd or
+> non-existent key makes the agent fail at startup. Only use real OnTime config fields
+> (see `ontime/etc/config/standalone.yaml` in the miggo-ontime repo).
+
+## Curated values (first-class)
+
+| Value | Purpose |
+|---|---|
+| `miggoOntime.logLevel` | `info` / `debug` / `warn` / `error` |
+| `miggoOntime.features` | feature list (default: `hold, procfs, detect, detections, enricher`) |
+| `miggoOntime.events` | enabled detection recipes (default includes `cloud_meta_probe`) |
+| `miggoOntime.otel.serviceName` | `service.name` on emitted OTel records |
+| `miggoOntime.otel.eventsPerSec` | per-second caps for high-frequency events |
+| `miggoOntime.health.enabled` | run the health server + exec probe (default `true`) |
+| `miggoOntime.stdout` | also emit to the stdout sink (debugging; default `false`) |
+| `miggoOntime.configOverrides` | escape hatch — see below |
+
+## `configOverrides` examples
+
+### 1. Tune intervals / caches under heavy process churn
+
+*Why:* on very busy nodes, short-lived processes can be evicted from the eBPF maps
+before their file/exec refs are correlated. Shorter intervals + bigger caches help.
+
+```yaml
+miggoOntime:
+  configOverrides:
+    intervals:
+      file-access: 3
+      env-vars: 3
+    caches:
+      task-file: 512
+      file-task: 512
+```
+
+### 2. Try the firewall feature (detection → active enforcement)
+
+*Why:* `firewall` is an internal-only feature, not enabled by default, but you can
+trial enforcement in a test cluster. Add it to `features` and supply a policy.
+
+```yaml
+miggoOntime:
+  features: [hold, procfs, detect, detections, enricher, firewall]
+  configOverrides:
+    firewall_policy:
+      policy: allow
+      deny:
+        - example.com
+```
+
+### 3. Try AI inference (event / noise reduction)
+
+*Why:* `inference` is internal-only; experiment by enabling the feature and pointing it
+at an endpoint.
+
+```yaml
+miggoOntime:
+  features: [hold, procfs, detect, detections, enricher, inference]
+  configOverrides:
+    feature_options:
+      inference:
+        enabled: true
+        url: "http://my-inference:8080/api/v1/chat/completions"
+        model: "XAI.grok-4.3"
+        mode: score
+```
+
+### 4. Enable the scoring pipeline / in-memory retainer
+
+*Why:* internal-only experimentation with event scoring / retention.
+
+```yaml
+miggoOntime:
+  features: [hold, procfs, detect, detections, enricher, pipeline, retainer]
+  configOverrides:
+    feature_options:
+      pipeline:
+        scoring: true
+      retainer:
+        inmemory: true
+```
+
+### 5. Add the stdout sink for debugging
+
+*Why:* see raw events in the pod logs. Prefer the dedicated toggle:
+
+```yaml
+miggoOntime:
+  stdout: true
+```
+
+…which is equivalent to overriding the sink list (note: lists replace, so include
+`otel` too):
+
+```yaml
+miggoOntime:
+  configOverrides:
+    sinks: [otel, stdout]
+```
+
+### 6. Enable extra detection recipes
+
+*Why:* turn on more detections than the default set. OnTime has no compile-time block
+list, so any listed recipe is enabled.
+
+```yaml
+miggoOntime:
+  events:
+    - cloud_meta_probe
+    - net_flow
+    - fw_drop
+    - badware_domain
+    - ld_preload_abuse
+```
+
+## What you cannot override
+
+- **`sink_options.otel.endpoint`** — always set by the chart to the in-cluster
+  Collector. (Service name and rates *are* overridable.)

--- a/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
@@ -425,7 +425,7 @@ data:
                 new_value: Miggo Collector
               - action: add_label
                 new_label: chart_version
-                new_value: 0.0.222
+                new_value: 0.0.224
 
       batch/metrics:
         timeout: 10s

--- a/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.222
+    helm.sh/chart: miggo-0.0.224
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.618.6"
+    app.kubernetes.io/version: "v26.624.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,14 +23,14 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2f500154f840691b3184076457edaa233fe5c1bf8e6dff82b125c0cabe4b3fd7
+        checksum/config: d40852b13179dc6e555e4585e0eb98516be30b5c0b915b09b4991905bcc5cbc7
       labels:
         component: collector
         miggo.io/app: example-collector
-        helm.sh/chart: miggo-0.0.222
+        helm.sh/chart: miggo-0.0.224
         app.kubernetes.io/name: miggo-collector
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.618.6"
+        app.kubernetes.io/version: "v26.624.3"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: example-collector
       initContainers:
         - name: collector-init-container
-          image: "registry.miggo.io/miggo/miggo-collector:v26.618.6"
+          image: "registry.miggo.io/miggo/miggo-collector:v26.624.3"
           securityContext:
             runAsGroup: 65532
             runAsNonRoot: true
@@ -75,7 +75,7 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
-          image: "registry.miggo.io/miggo/miggo-collector:v26.618.6"
+          image: "registry.miggo.io/miggo/miggo-collector:v26.624.3"
           imagePullPolicy: IfNotPresent
           args:
             - --config

--- a/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.222
+    helm.sh/chart: miggo-0.0.224
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.618.6"
+    app.kubernetes.io/version: "v26.624.3"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 

--- a/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.222
+    helm.sh/chart: miggo-0.0.224
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.618.6"
+    app.kubernetes.io/version: "v26.624.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,10 +23,10 @@ spec:
         checksum/config: 6ed877707581906ad34573544b36de695bd4e68848d208fc2a19372f691cdd49
       labels:
         component: miggo-runtime
-        helm.sh/chart: miggo-0.0.222
+        helm.sh/chart: miggo-0.0.224
         app.kubernetes.io/name: miggo-runtime
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.618.6"
+        app.kubernetes.io/version: "v26.624.3"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -40,7 +40,7 @@ spec:
         - name: miggo-runtime
           securityContext:
             privileged: true
-          image: "registry.miggo.io/miggo/miggo-runtime:v26.618.6"
+          image: "registry.miggo.io/miggo/miggo-runtime:v26.624.3"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -52,7 +52,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.222
+            - --chart-version=0.0.224
             - --disable-profiler=false
             - --enable-network-tracing=false
             - --enable-file-access-tracing=false
@@ -112,7 +112,7 @@ spec:
           - name: unix-socket
             mountPath: /tmp/grpc
         - name: profiler
-          image: "registry.miggo.io/miggo/miggo-profiler:v26.618.6"
+          image: "registry.miggo.io/miggo/miggo-profiler:v26.624.3"
           imagePullPolicy: IfNotPresent
           command:
             - /root/ebpf-profiler

--- a/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-pod-watcher-cr
   labels:
-    helm.sh/chart: miggo-0.0.222
+    helm.sh/chart: miggo-0.0.224
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.618.6"
+    app.kubernetes.io/version: "v26.624.3"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-pod-watcher-crb
   labels:
-    helm.sh/chart: miggo-0.0.222
+    helm.sh/chart: miggo-0.0.224
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.618.6"
+    app.kubernetes.io/version: "v26.624.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.222
+    helm.sh/chart: miggo-0.0.224
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.618.6"
+    app.kubernetes.io/version: "v26.624.3"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 

--- a/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.222
+    helm.sh/chart: miggo-0.0.224
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.618.6"
+    app.kubernetes.io/version: "v26.624.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,10 +23,10 @@ spec:
       annotations:
       labels:
         component: miggo-scanner
-        helm.sh/chart: miggo-0.0.222
+        helm.sh/chart: miggo-0.0.224
         app.kubernetes.io/name: miggo-scanner
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.618.6"
+        app.kubernetes.io/version: "v26.624.3"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -39,7 +39,7 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
-          image: "registry.miggo.io/miggo/miggo-scanner:v26.618.6"
+          image: "registry.miggo.io/miggo/miggo-scanner:v26.624.3"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -51,11 +51,11 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.222
+            - --chart-version=0.0.224
             - --queue-size=10000
             
             - --cache-flush-interval=168h
-            - --cache-cleanup-interval=1h
+            - --cache-cleanup-interval=15m
             - --cache-size=10000
             
             - --cache-cm-name=example-cache

--- a/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.222
+    helm.sh/chart: miggo-0.0.224
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.618.6"
+    app.kubernetes.io/version: "v26.624.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
 automountServiceAccountToken: true

--- a/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.222
+    helm.sh/chart: miggo-0.0.224
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.618.6"
+    app.kubernetes.io/version: "v26.624.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -21,13 +21,13 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/values: 54235a249eb0896296c72d49305bba6aeed0f3807a7de29be338a489baa9d1e8
+        checksum/values: 670996fd560523949dc66bc7e0973e1cf47aec356b1d3af305c76833677d6495
       labels:
         component: miggo-watch
-        helm.sh/chart: miggo-0.0.222
+        helm.sh/chart: miggo-0.0.224
         app.kubernetes.io/name: miggo-watch
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.618.6"
+        app.kubernetes.io/version: "v26.624.3"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -40,7 +40,7 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
-          image: "registry.miggo.io/miggo/miggo-watch:v26.618.6"
+          image: "registry.miggo.io/miggo/miggo-watch:v26.624.3"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -52,7 +52,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.222
+            - --chart-version=0.0.224
             - --interval=1h
             - --image-tracker-interval=1h
             - --exclude=pod,replica-set

--- a/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.222
+    helm.sh/chart: miggo-0.0.224
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.618.6"
+    app.kubernetes.io/version: "v26.624.3"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 

--- a/charts/miggo/examples/default/rendered/miggo-watch/values-rendered-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/values-rendered-cm.yaml
@@ -86,6 +86,49 @@ data:
       useGOMEMLIMIT: true
       volumeMounts: []
       volumes: []
+    miggoOntime:
+      affinity: {}
+      configOverrides: {}
+      enabled: false
+      events:
+      - cloud_meta_probe
+      extraArgs: {}
+      extraEnvs: []
+      extraEnvsFrom: []
+      features:
+      - hold
+      - procfs
+      - detect
+      - detections
+      - enricher
+      health:
+        enabled: true
+      hostIPC: true
+      hostPID: true
+      image:
+        repository: miggo/miggo-ontime
+      logLevel: info
+      nodeSelector:
+        kubernetes.io/os: linux
+      otel:
+        eventsPerSec:
+          fw_drop: 100
+          net_flow: 500
+        serviceName: miggo-ontime
+      priorityClassName: ""
+      resources:
+        limits:
+          cpu: "1"
+          memory: 1Gi
+        requests:
+          cpu: 500m
+          memory: 512Mi
+      securityContext:
+        privileged: true
+      stdout: false
+      tolerations: []
+      volumeMounts: []
+      volumes: []
     miggoRuntime:
       affinity: {}
       cgroupRegistryCleanInterval: 1h
@@ -168,7 +211,7 @@ data:
       annotations: {}
       config:
         cache:
-          cleanupInterval: 1h
+          cleanupInterval: 15m
           configMap:
             enabled: true
             name: ""

--- a/charts/miggo/templates/miggo-ontime/_helpers.tpl
+++ b/charts/miggo/templates/miggo-ontime/_helpers.tpl
@@ -1,0 +1,83 @@
+{{/*
+Common labels
+*/}}
+{{- define "miggoOntime.labels" -}}
+helm.sh/chart: {{ include "miggo.chart" . }}
+{{ include "miggoOntime.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "miggoOntime.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "miggo.name" . }}-ontime
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+OnTime base config (rendered into /etc/ontime/config.yaml). The structural defaults
+(intervals, caches, functionalities, feature_options.detections) are fixed here; the
+curated miggoOntime values feed the tunable parts. config-cm.yaml deep-merges
+miggoOntime.configOverrides over this and then re-asserts the otel sink endpoint, so
+the Collector wiring is always chart-controlled.
+*/}}
+{{- define "miggoOntime.baseConfig" -}}
+run_time:
+  log-level: {{ .Values.miggoOntime.logLevel }}
+  profiler: false
+  health: {{ .Values.miggoOntime.health.enabled }}
+  metrics: true
+  cardinal: true
+  stdout: stdout
+  stderr: stderr
+intervals:
+  env-vars: 6
+  file-access: 6
+  network-peers: 6
+  network-flows: 9
+caches:
+  rec-tasks: 32
+  tasks: 64
+  cmds: 32
+  args: 32
+  files: 128
+  dirs: 32
+  bases: 64
+  task-file: 256
+  file-task: 256
+  task-ref: 256
+  flows: 128
+  task-flow: 128
+  flow-task: 128
+  flow-ref: 128
+functionalities:
+  - ontime
+features:
+  {{- toYaml .Values.miggoOntime.features | nindent 2 }}
+feature_options:
+  detect:
+  detections:
+    builtin:
+      enabled: true
+    public:
+      enabled: false
+sinks:
+  - otel
+  {{- if .Values.miggoOntime.stdout }}
+  - stdout
+  {{- end }}
+sink_options:
+  otel:
+    endpoint: {{ include "otlpProfilesEndpoint" . | quote }}
+    service_name: {{ .Values.miggoOntime.otel.serviceName | quote }}
+    {{- with .Values.miggoOntime.otel.eventsPerSec }}
+    events_per_sec:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+events:
+  {{- toYaml .Values.miggoOntime.events | nindent 2 }}
+{{- end -}}

--- a/charts/miggo/templates/miggo-ontime/config-cm.yaml
+++ b/charts/miggo/templates/miggo-ontime/config-cm.yaml
@@ -1,0 +1,21 @@
+{{ if .Values.miggoOntime.enabled }}
+{{- /* Build the config: chart base, deep-merge user overrides, then force the otel
+       sink endpoint so the in-cluster Collector wiring is always chart-controlled. */}}
+{{- $cfg := include "miggoOntime.baseConfig" . | fromYaml }}
+{{- $cfg = mergeOverwrite $cfg (deepCopy .Values.miggoOntime.configOverrides) }}
+{{- $_ := set (index $cfg "sink_options" "otel") "endpoint" (include "otlpProfilesEndpoint" .) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "miggo.fullname" . }}-ontime-config
+  namespace: {{ include "miggo.namespace" . }}
+  labels:
+    {{- include "miggo.labels" . | nindent 4 }}
+data:
+  # OnTime reads this as `ontime --config /etc/ontime/config.yaml`. Base config is from
+  # the curated miggoOntime values; miggoOntime.configOverrides is deep-merged on top;
+  # the chart re-asserts the otel sink endpoint (in-cluster Collector). Override
+  # examples: see docs/miggo-ontime.md.
+  config.yaml: |
+{{ toYaml $cfg | indent 4 }}
+{{- end }}

--- a/charts/miggo/templates/miggo-ontime/daemonset.yaml
+++ b/charts/miggo/templates/miggo-ontime/daemonset.yaml
@@ -1,0 +1,182 @@
+{{ if .Values.miggoOntime.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "miggo.fullname" . }}-ontime
+  namespace: {{ include "miggo.namespace" . }}
+  labels:
+    {{- include "miggo.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+    {{- with .Values.miggoOntime.labels }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+  annotations:
+  {{- with .Values.annotations }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  {{- with .Values.miggoOntime.annotations }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+    {{- include "miggoOntime.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/miggo-ontime/config-cm.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.miggoOntime.podAnnotations }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      labels:
+        component: miggo-ontime
+        {{- include "miggoOntime.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+        {{- with .Values.miggoOntime.podLabels }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+    spec:
+      imagePullSecrets:
+        {{- with .Values.imagePullSecrets }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- include "miggoImagePullSecrets" . | nindent 8 }}
+      serviceAccountName: {{ include "miggo.serviceAccountName" . }}-ontime
+      {{- with (include "miggo.podSecurityContext.runtime" .) }}
+      securityContext:
+        {{- . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: miggo-ontime
+          securityContext:
+            {{- toYaml .Values.miggoOntime.securityContext | nindent 12 }}
+          {{- if .Values.miggoOntime.image.fullPath }}
+          image: "{{ .Values.miggoOntime.image.fullPath }}"
+          {{- else }}
+          image: "{{ .Values.image.registry }}/{{ .Values.miggoOntime.image.repository }}:{{ .Values.miggoOntime.image.tag | default "latest" }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.miggoOntime.image.pullPolicy | default .Values.image.pullPolicy }}
+          args:
+            - --config
+            - /etc/ontime/config.yaml
+          {{- range $key, $value := .Values.miggoOntime.extraArgs }}
+            {{- if kindIs "invalid" $value }}
+            - --{{ $key }}
+            {{- else }}
+            - --{{ $key }}={{ $value }}
+            {{- end }}
+          {{- end }}
+          envFrom:
+          {{- with .Values.extraEnvsFrom }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.miggoOntime.extraEnvsFrom }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          env:
+          - name: MIGGO_ONTIME_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          {{- with .Values.extraEnvs }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.miggoOntime.extraEnvs }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- if .Values.miggoOntime.health.enabled }}
+          # OnTime's health server binds 127.0.0.1:8082, so kubelet httpGet (pod IP)
+          # can't reach it — use an exec probe inside the container (Alpine ships wget).
+          # Swap to httpGet once miggo-ontime can bind the health server externally.
+          livenessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "wget -q -O- http://127.0.0.1:8082/health >/dev/null 2>&1"]
+            periodSeconds: 10
+            timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.failureThreshold }}
+          readinessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "wget -q -O- http://127.0.0.1:8082/health >/dev/null 2>&1"]
+            periodSeconds: 10
+            timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.miggoOntime.resources | nindent 12 }}
+          volumeMounts:
+          - name: ontime-config
+            mountPath: /etc/ontime
+            readOnly: true
+          - name: debugfs
+            mountPath: /sys/kernel/debug
+            readOnly: true
+          - name: tracefs
+            mountPath: /sys/kernel/tracing
+            readOnly: true
+          - name: cgroupfs
+            mountPath: /cgroup
+            readOnly: true
+          {{- with .Values.volumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.miggoOntime.volumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+      hostIPC: {{ .Values.miggoOntime.hostIPC }}
+      hostPID: {{ .Values.miggoOntime.hostPID }}
+      volumes:
+      - name: ontime-config
+        configMap:
+          name: {{ include "miggo.fullname" . }}-ontime-config
+      - name: debugfs
+        hostPath:
+          path: /sys/kernel/debug
+      - name: tracefs
+        hostPath:
+          path: /sys/kernel/tracing
+      - name: cgroupfs
+        hostPath:
+          path: /sys/fs/cgroup
+      {{- with .Values.volumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.miggoOntime.volumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      nodeSelector:
+      {{- with .Values.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.miggoOntime.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or .Values.affinity .Values.miggoOntime.affinity }}
+      affinity:
+        {{- with .Values.affinity }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.miggoOntime.affinity }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- if or .Values.tolerations .Values.miggoOntime.tolerations }}
+      tolerations:
+        {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.miggoOntime.tolerations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      {{- $priorityClassName := .Values.miggoOntime.priorityClassName | default .Values.priorityClassName | default "system-node-critical" }}
+      {{- if $priorityClassName }}
+      priorityClassName: {{ $priorityClassName }}
+      {{- end }}
+{{ end }}

--- a/charts/miggo/templates/miggo-ontime/role.yaml
+++ b/charts/miggo/templates/miggo-ontime/role.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.miggoOntime.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "miggo.fullname" . }}-ontime-pod-watcher-cr
+  labels:
+  {{- include "miggo.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - watch
+  - list
+{{- end }}
+
+{{- if and .Values.miggoOntime.enabled (eq .Values.config.platform "openshift") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "miggo.fullname" . }}-ontime-scc-privileged
+  labels:
+  {{- include "miggo.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+    - "security.openshift.io"
+    resources:
+    - "securitycontextconstraints"
+    resourceNames:
+    - "privileged"
+    verbs:
+    - "use"
+{{- end }}

--- a/charts/miggo/templates/miggo-ontime/rolebinding.yaml
+++ b/charts/miggo/templates/miggo-ontime/rolebinding.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.miggoOntime.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "miggo.fullname" . }}-ontime-pod-watcher-crb
+  labels:
+  {{- include "miggo.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "miggo.fullname" . }}-ontime-pod-watcher-cr
+subjects:
+- kind: ServiceAccount
+  name: {{ include "miggo.fullname" . }}-ontime
+  namespace: '{{ include "miggo.namespace" . }}'
+{{- end }}
+
+{{- if and .Values.miggoOntime.enabled (eq .Values.config.platform "openshift") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "miggo.fullname" . }}-ontime-scc-privileged
+  labels:
+  {{- include "miggo.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "miggo.fullname" . }}-ontime-scc-privileged
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "miggo.fullname" . }}-ontime
+    namespace: '{{ include "miggo.namespace" . }}'
+{{- end }}

--- a/charts/miggo/templates/miggo-ontime/serviceaccount.yaml
+++ b/charts/miggo/templates/miggo-ontime/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.miggoOntime.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "miggo.fullname" . }}-ontime
+  namespace: {{ include "miggo.namespace" . }}
+  labels:
+    {{- include "miggo.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/miggo/tests/ontime/test.yaml
+++ b/charts/miggo/tests/ontime/test.yaml
@@ -1,0 +1,82 @@
+suite: ontime
+
+release:
+  name: miggo
+  namespace: miggo-space
+
+templates:
+  - templates/miggo-ontime/daemonset.yaml
+  - templates/miggo-ontime/config-cm.yaml
+  - templates/miggo-ontime/serviceaccount.yaml
+
+values:
+  - values.yaml
+
+tests:
+  - it: should render the DaemonSet wired to the config file with an exec health probe
+    template: templates/miggo-ontime/daemonset.yaml
+    chart:
+      version: '1.0.0'
+      appVersion: '1.0.0'
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - equal:
+          path: metadata.name
+          value: miggo-ontime
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: registry.miggo.io/miggo/miggo-ontime:latest
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --config
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: /etc/ontime/config.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[2]
+          pattern: wget .*127\.0\.0\.1:8082/health
+
+  - it: should render the config with otel sink to the collector, cardinal on, and cloud_meta_probe
+    template: templates/miggo-ontime/config-cm.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: miggo-ontime-config
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: cloud_meta_probe
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'cardinal: true'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'miggo-collector\.miggo-space\.svc\.cluster\.local:4317'
+
+  - it: should deep-merge configOverrides into the rendered config
+    template: templates/miggo-ontime/config-cm.yaml
+    set:
+      miggoOntime.configOverrides.intervals.file-access: 3
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'file-access: 3'
+
+  - it: should create its own service account
+    template: templates/miggo-ontime/serviceaccount.yaml
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: miggo-ontime
+
+  - it: should render nothing when the feature gate is off
+    template: templates/miggo-ontime/daemonset.yaml
+    set:
+      miggoOntime.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/miggo/tests/ontime/values.yaml
+++ b/charts/miggo/tests/ontime/values.yaml
@@ -1,0 +1,4 @@
+# Baseline for the OnTime suite: the feature gate on. Individual tests override
+# via `set:` (e.g. to assert the gate renders nothing when off).
+miggoOntime:
+  enabled: true

--- a/charts/miggo/values.yaml
+++ b/charts/miggo/values.yaml
@@ -469,6 +469,209 @@ miggoRuntime:
         memory: "100Mi"
         cpu: "100m"
 
+miggoOntime:
+  # -- Install the OnTime runtime detection agent on each cluster node. OnTime runs
+  # in parallel to the Runtime and Profiler and submits detection events to the
+  # Collector. It depends only on the Collector, not on miggoRuntime, so it is gated
+  # independently.
+  enabled: false
+
+  image:
+    # -- Image repository
+    repository: miggo/miggo-ontime
+    # -- Image tag. Defaults to "latest" — OnTime releases on its own version line
+    # (v0.0.x), independent of the chart appVersion. Pin to a specific tag for production.
+    tag:
+    # -- Optional full image path override. If set, takes precedence over registry/repository/tag settings.
+    # Useful for local development with Minikube or when needing to specify a complete custom image path
+    fullPath:
+    # -- Image pull policy. Specifies when Kubernetes should pull the container image
+    pullPolicy:
+
+  #### OnTime config. The chart renders /etc/ontime/config.yaml and passes it via
+  #### --config. Structural defaults (intervals, caches, functionalities) are fixed
+  #### by the chart; the tunables below are what you normally change. The OTel sink
+  #### endpoint is wired by the chart to the in-cluster Collector.
+
+  # -- OnTime log level: info, debug, warn, error
+  logLevel: info
+
+  # -- OnTime features to enable (see the OnTime config reference)
+  features:
+    - hold
+    - procfs
+    - detect
+    - detections
+    - enricher
+
+  # -- Detection recipes (events) to enable. Mirrors the OnTime standalone config
+  # catalog, grouped by detection method; everything is commented out except the
+  # single POC detection (cloud_meta_probe). Uncomment entries to enable more —
+  # OnTime has no compile-time block list, so any listed recipe is enabled.
+  # net_flow / fw_drop are telemetry (not detections) and stay off by default.
+  events:
+    # Informational / telemetry events.
+    # - fw_drop
+    # - net_flow
+    # - sys_profile
+
+    # Detection recipes for file access patterns.
+    # - file_example
+    # - log_wipe
+    # - self_delete
+    # - cap_modify
+    # - proc_mem_write
+    # - core_path_write
+    # - cpu_probe
+    # - cred_file_access
+    # - miner_drop
+    # - proc_env_read
+    # - fs_probe
+    # - shlib_write
+    # - jvm_debug_inject
+    # - jvm_agent_inject
+    # - hw_probe
+    # - os_probe
+    # - net_if_probe
+    # - sys_state_probe
+    # - repo_cfg_write
+    # - pam_cfg_write
+    # - sched_debug_probe
+    # - shell_cfg_write
+    # - tls_cert_read
+    # - sudo_cfg_write
+    # - sysrq_probe
+    # - bpf_cfg_read
+    # - kern_prot_bypass
+
+    # Detection recipes for execution patterns.
+    # - exec_example
+    # - loader_exec
+    # - jit_exec
+    # - cred_grep
+    # - miner_exec
+    # - encoder_exec
+    # - dos_tool
+    # - odd_path_exec
+    # - file_flags_set
+    # - stealth_exec
+    # - interp_to_shell
+    # - exfil_tool
+    # - mitm_tool
+    # - scan_tool
+    # - sniffer_tool
+    # - net_offens_tool
+    # - passwd_run
+    # - ctr_escape
+    # - webshell_exec
+    # - webshell_spawn
+
+    # Detection recipes for environment variable patterns.
+    # - ld_preload_abuse
+
+    # Detection recipes for network peer patterns.
+    - cloud_meta_probe  # enabled by default for the POC
+    # - peer_example
+    # - adult_domain
+    # - dga_domain
+    # - dga_domain_light
+    # - badware_domain
+    # - dyndns_domain
+    # - typosquat_domain
+    # - gambling_domain
+    # - gambling_domain_light
+    # - new_domain
+    # - new_domain_light
+    # - phish_domain
+    # - phish_domain_light
+    # - piracy_domain
+    # - plaintext_proto
+    # - c2_domain
+    # - c2_domain_light
+    # - c2_domain_medium
+    # - tracker_domain
+    # - vpn_bypass_domain
+
+    # Detections with specific eBPF logic (kernel LCE). Enable only on matching
+    # vulnerable kernels.
+    # - copy_fail_attempt
+    # - dirty_frag_attempt
+    # - fragnesia_attempt
+    # - ssh_keysign_pwn_attempt
+    # - dirty_cbc_attempt
+    # - pin_theft_attempt
+    # - nft_catchall_uaf_attempt
+
+  otel:
+    # -- service.name attribute on emitted OTel records
+    serviceName: miggo-ontime
+    # -- Per-second caps for high-frequency observation events
+    eventsPerSec:
+      fw_drop: 100
+      net_flow: 500
+
+  health:
+    # -- Run OnTime's internal health server and add an exec liveness/readiness probe
+    # that checks it. The server binds 127.0.0.1:8082 (localhost only), so the probe
+    # is an in-container `wget` exec rather than httpGet — once miggo-ontime can bind
+    # the health server externally, this becomes a plain httpGet. Probe timeouts and
+    # thresholds come from the global .Values.probes.
+    enabled: true
+
+  # -- Also send events to stdout (alongside the otel sink) for debugging.
+  stdout: false
+
+  # -- Free-form map deep-merged over the chart's rendered OnTime config. Use it to
+  # tune any field not exposed as a first-class value above — intervals, caches,
+  # internal-only features (inference / firewall / pipeline / retainer / github) and
+  # their feature_options, extra sinks, per-event options, etc. Lists replace, maps
+  # merge. The chart always re-asserts the otel sink endpoint, so overriding it has no
+  # effect. See docs/miggo-ontime.md for worked examples.
+  configOverrides: {}
+
+  # -- Additional command-line arguments (e.g. network-flows, report). OnTime is
+  # configured via the config file; these are extra flags only.
+  extraArgs: {}
+  # -- Additional environment variables
+  extraEnvs: []
+  # -- Additional environment variables from sources
+  extraEnvsFrom: []
+  # -- Additional volumes
+  volumes: []
+  # -- Additional volume mounts for all containers
+  volumeMounts: []
+
+  # -- Node selector settings
+  nodeSelector:
+    kubernetes.io/os: linux
+
+  # -- Tolerations for the miggo-ontime DaemonSet. Global tolerations specified in
+  # .Values.tolerations will be merged with this list.
+  tolerations: []
+
+  # -- Affinity settings for the miggo-ontime DaemonSet. Global affinity specified in
+  # .Values.affinity will be merged with this configuration.
+  affinity: {}
+
+  # -- Priority class name (defaults to global priorityClassName or system-node-critical)
+  priorityClassName: ""
+
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+  securityContext:
+    privileged: true
+
+  # -- Use the host's pid namespace.
+  hostPID: true
+  # -- Use the host's ipc namespace.
+  hostIPC: true
+
 miggoCollector:
   # -- Enable Collector component
   enabled: true


### PR DESCRIPTION
Adds **MiggoOnTime** to the chart as a standalone, config-driven runtime-detection sensor, for the Miggo-OnTime POC.

## Design: standalone component, not a runtime sidecar
The Profiler is nested under `miggoRuntime` because it co-processes with Runtime (shared unix socket, same pod). OnTime has no such coupling — its only dependency is the **Collector**. So it's its own component (own DaemonSet, `miggoOntime.enabled` gate, own ServiceAccount + pod-watcher RBAC), peer to `miggo-collector` / `miggo-scanner` / `miggo-watch` — **not** gated by `miggoRuntime.enabled`. It still runs alongside the other sensors (a DaemonSet); it's just gated/lifecycled independently. Pod spec mirrors `miggo-runtime` (privileged eBPF security context, `debugfs`/`tracefs`/`cgroupfs` mounts, `hostPID`/`hostIPC`). Image: `registry.miggo.io/miggo/miggo-ontime`.

## Config-driven (this is the core of the PR)
OnTime runs as `ontime --config /etc/ontime/config.yaml`. The chart renders that file into a ConfigMap and mounts it:
- **Base config** from curated values + fixed structural defaults (intervals `6/6/6/9`, caches, functionalities, `feature_options.detections`, `run_time.cardinal: true`).
- **`miggoOntime.configOverrides`** is **deep-merged** over the base (maps merge, lists replace) — the escape hatch for any field not exposed as a first-class value (intervals, caches, internal-only features like inference/firewall/pipeline/retainer/github, extra sinks, per-event options).
- The chart always **re-asserts the `otel` sink endpoint** to the in-cluster Collector (OTLP gRPC `:4317`), so it can't be misconfigured.

### Curated (first-class) values
`logLevel`, `features`, `events`, `otel.serviceName`, `otel.eventsPerSec`, `health.enabled`, `stdout` (debug sink), `configOverrides`.

### Events
Only **`cloud_meta_probe`** is enabled by default (the POC detection). The **full OnTime detection catalog is listed-but-commented in `values.yaml`** (grouped by detection method, mirroring `standalone.yaml`), so more are enabled by uncommenting. `net_flow`/`fw_drop` telemetry are off by default. OnTime has no compile-time block list, so any listed recipe is enabled.

### Resources
Requests **500m CPU / 512Mi**, limits **1 CPU / 1Gi**.

## Health
`health.enabled: true` by default. OnTime's health server binds `127.0.0.1:8082` (localhost only), so the probe is an **in-container `exec` `wget`** (image is Alpine) rather than `httpGet`. Swaps to `httpGet` once miggo-ontime can bind the health server externally (separate, optional miggo-ontime change).

## Feature gate
`miggoOntime.enabled: false` by default — opt-in (turn on in the Biggo/pre-prod values).

## Docs
**`charts/miggo/docs/miggo-ontime.md`** — how the config is produced (base → overrides → endpoint), merge semantics, the strict-unknown-field caveat, a curated-values table, and worked `configOverrides` examples (intervals/caches tuning, firewall, inference, pipeline/retainer, stdout sink, extra events) + what can't be overridden (the otel endpoint).

## Tests run locally
- `helm lint` — clean
- `helm unittest` — **21 suites / 127 tests**, incl. a `tests/ontime` suite asserting `--config` wiring, the otel endpoint / `cloud_meta_probe` / `cardinal: true` in the rendered config, the exec health probe, and that `configOverrides.intervals.file-access: 3` deep-merges into the rendered config.
- `make check-examples` — passes (examples regenerated; chart bumped to 0.0.224).

Linear: SEN-468 (project: Miggo-OnTime POC)