### PR TITLE
enable pprof by default + scrape and send it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,13 +16,6 @@ permissions:
   statuses: write
 
 jobs:
-  verify-and-bump:
-    uses: ./.github/workflows/bump-version.yaml
-
-  generate-helm-docs:
-    needs: verify-and-bump
-    uses: ./.github/workflows/run-helm-docs.yaml
-
   helm-lint:
     needs: verify-and-bump
     uses: ./.github/workflows/helm-lint.yaml

--- a/charts/miggo/README.md
+++ b/charts/miggo/README.md
@@ -220,8 +220,7 @@ The following table lists the configurable parameters of the miggo chart and the
 | miggoScanner.resources.limits.memory | string | `"4Gi"` |  |
 | miggoScanner.resources.requests.cpu | string | `"1000m"` |  |
 | miggoScanner.resources.requests.memory | string | `"2Gi"` |  |
-| miggoScanner.serviceAccount.annotations | object | `{}` | Annotations to add to the chart-created ServiceAccount. Ignored when name is set (pre-existing SA). |
-| miggoScanner.serviceAccount.name | string | `""` | Name of a pre-existing ServiceAccount to use. When empty (default), the chart creates its own ServiceAccount. When set, the chart skips creation and uses this name — for when your IaC (e.g. Terraform + IRSA / EKS Pod Identity) owns the ServiceAccount lifecycle. |
+| miggoScanner.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | miggoScanner.useGOMEMLIMIT | bool | `true` | When enabled, the chart will set the GOMEMLIMIT env var to 80% of the configured resources.limits.memory. If no resources.limits.memory are defined then enabling does nothing. It is HIGHLY recommend to enable this setting and set a value for resources.limits.memory. |
 | miggoScanner.volumeMounts | list | `[]` | Additional volume mounts |
 | miggoScanner.volumes | list | `[]` | Additional volumes |

--- a/charts/miggo/README.md
+++ b/charts/miggo/README.md
@@ -259,6 +259,13 @@ The following table lists the configurable parameters of the miggo chart and the
 | podAnnotations | object | `{}` | Pod annotations to add to all pods |
 | podLabels | object | `{}` | Pod labels to add to all pods |
 | podSecurityContext | object | `{}` | DEPRECATED: superseded by manageSecurityContext. While manageSecurityContext is true, a populated value here overrides the managed pod security context for all pods. |
+| pprof.cpu.enabled | bool | `false` | Enable CPU profile scraping by the Collector's diagnostic pipeline |
+| pprof.cpu.interval | string | `"10s"` | How often to trigger a CPU profile collection |
+| pprof.cpu.period | int | `10` | Duration of each blocking CPU profile collection in seconds (passed as ?seconds=N to the pprof HTTP endpoint). Must be an integer. |
+| pprof.memory.enabled | bool | `true` | Enable heap profile scraping by the Collector's diagnostic pipeline |
+| pprof.memory.interval | string | `"10s"` | How often to collect a heap snapshot |
+| pprof.port | int | `6050` | Port to expose pprof HTTP endpoints on for Scanner, Watch, and Runtime. 0 disables pprof entirely (default). When non-zero, the pod label miggo.io/pprof-port is set so the Collector can auto-discover and scrape these endpoints for self-diagnostic profiling. |
+| pprof.profilerPort | int | `6051` | Separate pprof port for the Profiler sidecar container, which shares the Runtime pod's network namespace and therefore cannot reuse pprof.port. 0 disables profiler pprof (default). Only relevant when miggoRuntime.profiler.enabled is true. |
 | priorityClassName | string | `""` | Priority class name for all pods |
 | probes.failureThreshold | int | `5` | Failure threshold for liveness and readiness probes across all components |
 | probes.timeoutSeconds | int | `10` | Timeout seconds for liveness and readiness probes across all components |

--- a/charts/miggo/README.md
+++ b/charts/miggo/README.md
@@ -264,8 +264,8 @@ The following table lists the configurable parameters of the miggo chart and the
 | pprof.cpu.period | int | `10` | Duration of each blocking CPU profile collection in seconds (passed as ?seconds=N to the pprof HTTP endpoint). Must be an integer. |
 | pprof.memory.enabled | bool | `true` | Enable heap profile scraping by the Collector's diagnostic pipeline |
 | pprof.memory.interval | string | `"10s"` | How often to collect a heap snapshot |
-| pprof.port | int | `6050` | Port to expose pprof HTTP endpoints on for Scanner, Watch, and Runtime. 0 disables pprof entirely (default). When non-zero, the pod label miggo.io/pprof-port is set so the Collector can auto-discover and scrape these endpoints for self-diagnostic profiling. |
-| pprof.profilerPort | int | `6051` | Separate pprof port for the Profiler sidecar container, which shares the Runtime pod's network namespace and therefore cannot reuse pprof.port. 0 disables profiler pprof (default). Only relevant when miggoRuntime.profiler.enabled is true. |
+| pprof.port | int | `6050` | Port to expose pprof HTTP endpoints on for Scanner, Watch, and Runtime. 0 disables pprof entirely. |
+| pprof.profilerPort | int | `6051` | Separate pprof port for the Profiler sidecar container, which shares the Runtime pod's network namespace and therefore cannot reuse pprof.port. 0 disables profiler pprof. |
 | priorityClassName | string | `""` | Priority class name for all pods |
 | probes.failureThreshold | int | `5` | Failure threshold for liveness and readiness probes across all components |
 | probes.timeoutSeconds | int | `10` | Timeout seconds for liveness and readiness probes across all components |

--- a/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
@@ -425,7 +425,7 @@ data:
                 new_value: Miggo Collector
               - action: add_label
                 new_label: chart_version
-                new_value: 0.0.228
+                new_value: 0.0.230
 
       batch/metrics:
         timeout: 10s

--- a/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
@@ -386,10 +386,6 @@ data:
               static_configs:
                 - targets: [ 'localhost:8888' ]
               metric_relabel_configs:
-                - source_labels: [__name__]
-                  regex: 'otelcol_(.*)'
-                  target_label: __name__
-                  replacement: 'miggocol_$1'
                 - target_label: "miggo-name"
                   replacement: "my-cluster"
                 - target_label: "node-name"
@@ -413,8 +409,12 @@ data:
           - default
 
     processors:
-      metricstransform:
+      metrics_transform:
         transforms:
+          - include: 'otelcol_(.*)'
+            match_type: regexp
+            action: update
+            new_name: "miggocol_$1"
           - include: miggocol_process_uptime
             match_type: strict
             new_name: miggo_component_status
@@ -425,7 +425,7 @@ data:
                 new_value: Miggo Collector
               - action: add_label
                 new_label: chart_version
-                new_value: 0.0.227
+                new_value: 0.0.228
 
       batch/metrics:
         timeout: 10s
@@ -440,22 +440,22 @@ data:
         metric_statements:
         - context: metric
           statements:
-            - set(name, Concat(["miggocol", name], "."))
+            - set(metric.name, Concat(["miggocol", metric.name], "."))
         - context: datapoint
           statements:
-            - merge_maps(attributes, resource.attributes, "insert")
-            - set(attributes["miggo-name"], "my-cluster")
-            - set(attributes["pod.hostname"], attributes["k8s.pod.name"])
-            - delete_key(attributes, "k8s.pod.name")
-            - set(attributes["node.name"], attributes["k8s.node.name"])
-            - delete_key(attributes, "k8s.node.name")
-            - delete_key(attributes, "container.id")
-            - delete_key(attributes, "k8s.pod.uid")
-            - delete_key(attributes, "otel.scope.name")
-            - delete_key(attributes, "otel.scope.version")
-            - delete_key(attributes, "pod.hostname")
-            - delete_key(attributes, "container.image.name")
-            - delete_key(attributes, "container.image.tag")
+            - merge_maps(datapoint.attributes, resource.attributes, "insert")
+            - set(datapoint.attributes["miggo-name"], "my-cluster")
+            - set(datapoint.attributes["pod.hostname"], datapoint.attributes["k8s.pod.name"])
+            - delete_key(datapoint.attributes, "k8s.pod.name")
+            - set(datapoint.attributes["node.name"], datapoint.attributes["k8s.node.name"])
+            - delete_key(datapoint.attributes, "k8s.node.name")
+            - delete_key(datapoint.attributes, "container.id")
+            - delete_key(datapoint.attributes, "k8s.pod.uid")
+            - delete_key(datapoint.attributes, "otel.scope.name")
+            - delete_key(datapoint.attributes, "otel.scope.version")
+            - delete_key(datapoint.attributes, "pod.hostname")
+            - delete_key(datapoint.attributes, "container.image.name")
+            - delete_key(datapoint.attributes, "container.image.tag")
 
       filter/self-logs:
         logs:
@@ -484,7 +484,7 @@ data:
       prometheus:
         endpoint: 0.0.0.0:8889
 
-      otlphttp:
+      otlp_http:
         traces_endpoint: https://collector.miggo.io/v1/traces
         metrics_endpoint: https://collector.miggo.io/v1/metrics
         logs_endpoint: https://collector.miggo.io/v1/logs
@@ -495,7 +495,9 @@ data:
     service:
       telemetry:
         resource:
-          origin: "selflogs"
+          attributes:
+            - name: origin
+              value: "selflogs"
         logs:
           encoding: json
           level: "INFO"
@@ -518,12 +520,13 @@ data:
         - health_check
         - oauth2client
         - k8s_leader_elector
+        - k8s_observer
       pipelines:
         profiles:
           receivers:
             - otlp
           exporters:
-            - otlphttp
+            - otlp_http
         metrics/sensors:
           receivers:
             - otlp
@@ -532,17 +535,17 @@ data:
           exporters:
             - debug
             - prometheus
-            - otlphttp
+            - otlp_http
         metrics/collector:
           receivers:
             - prometheus
           processors:
             - batch/metrics
-            - metricstransform
+            - metrics_transform
           exporters:
             - debug
             - prometheus
-            - otlphttp
+            - otlp_http
 
         metrics/k8s:
           receivers:
@@ -552,7 +555,7 @@ data:
             - transform/k8s_metric
           exporters:
             - prometheus
-            - otlphttp
+            - otlp_http
 
         traces:
           receivers:
@@ -561,7 +564,7 @@ data:
             - batch/traces
           exporters:
             - debug
-            - otlphttp
+            - otlp_http
         logs:
           receivers:
             - otlp
@@ -569,7 +572,7 @@ data:
             - batch/logs
           exporters:
             - debug
-            - otlphttp
+            - otlp_http
         logs/self:
           receivers:
             - otlp
@@ -578,6 +581,6 @@ data:
             - transform/collector-self-logs
             - batch/logs
           exporters:
-            - otlphttp
+            - otlp_http
 
 

--- a/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.227
+    helm.sh/chart: miggo-0.0.228
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.703.1"
+    app.kubernetes.io/version: "v26.706.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,14 +23,15 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb631bdb0dfa4bde4d5a32c5442b0b3f5fda48d98cb82341fcfe045bc21090c7
+        checksum/config: c722cf7c056a197468f0541e4c842f3b63d29ca3db2ef4ca2dbdec367038cde7
+        checksum/diagnostic-config: 3596c29323e3031ab643183daee6fa8305a9a9ff32088ff0acad6927a9ec01e2
       labels:
         component: collector
         miggo.io/app: example-collector
-        helm.sh/chart: miggo-0.0.227
+        helm.sh/chart: miggo-0.0.228
         app.kubernetes.io/name: miggo-collector
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.703.1"
+        app.kubernetes.io/version: "v26.706.1"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -41,7 +42,7 @@ spec:
       serviceAccountName: example-collector
       initContainers:
         - name: collector-init-container
-          image: "registry.miggo.io/miggo/miggo-collector:v26.703.1"
+          image: "registry.miggo.io/miggo/miggo-collector:v26.706.1"
           securityContext:
             runAsGroup: 65532
             runAsNonRoot: true
@@ -75,11 +76,13 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
-          image: "registry.miggo.io/miggo/miggo-collector:v26.703.1"
+          image: "registry.miggo.io/miggo/miggo-collector:v26.706.1"
           imagePullPolicy: IfNotPresent
           args:
             - --config
             - /etc/collector/config.yaml
+            - --config
+            - /etc/collector/diagnostic-pprof.yaml
             - --feature-gates
             - service.profilesSupport
           envFrom:
@@ -114,6 +117,9 @@ spec:
           volumeMounts:
           - name: collector-config
             mountPath: /etc/collector
+          - name: diagnostic-pprof-config
+            mountPath: /etc/collector/diagnostic-pprof.yaml
+            subPath: diagnostic-pprof.yaml
           
           - name: access-key
             mountPath: /etc/miggo-access-key
@@ -124,6 +130,9 @@ spec:
       - name: collector-config-cm
         configMap:
           name: collector-config-cm
+      - name: diagnostic-pprof-config
+        configMap:
+          name: diagnostic-pprof-config-cm
       
       - name: access-key
         secret:

--- a/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.228
+    helm.sh/chart: miggo-0.0.230
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.706.1"
+    app.kubernetes.io/version: "v26.708.4"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,15 +23,15 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c722cf7c056a197468f0541e4c842f3b63d29ca3db2ef4ca2dbdec367038cde7
-        checksum/diagnostic-config: 3596c29323e3031ab643183daee6fa8305a9a9ff32088ff0acad6927a9ec01e2
+        checksum/config: 0922ff6b253c4ddc67dfdd44df170a883d1a1bbbb070b40b990a39796f774259
+        checksum/diagnostic-config: 910452082d3a26a54f7d939f3f214eaca76a46ac4b7a421d9395d9672b05db36
       labels:
         component: collector
         miggo.io/app: example-collector
-        helm.sh/chart: miggo-0.0.228
+        helm.sh/chart: miggo-0.0.230
         app.kubernetes.io/name: miggo-collector
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.706.1"
+        app.kubernetes.io/version: "v26.708.4"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -42,7 +42,7 @@ spec:
       serviceAccountName: example-collector
       initContainers:
         - name: collector-init-container
-          image: "registry.miggo.io/miggo/miggo-collector:v26.706.1"
+          image: "registry.miggo.io/miggo/miggo-collector:v26.708.4"
           securityContext:
             runAsGroup: 65532
             runAsNonRoot: true
@@ -76,7 +76,7 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
-          image: "registry.miggo.io/miggo/miggo-collector:v26.706.1"
+          image: "registry.miggo.io/miggo/miggo-collector:v26.708.4"
           imagePullPolicy: IfNotPresent
           args:
             - --config

--- a/charts/miggo/examples/default/rendered/miggo-collector/diagnostic-pprof-config-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/diagnostic-pprof-config-cm.yaml
@@ -1,0 +1,76 @@
+---
+# Source: miggo/templates/miggo-collector/diagnostic-pprof-config-cm.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: diagnostic-pprof-config-cm
+  namespace: default
+data:
+  diagnostic-pprof.yaml: |
+    extensions:
+      k8s_observer:
+        auth_type: serviceAccount
+        observe_pods: true
+        observe_nodes: false
+        observe_services: false
+        namespaces:
+          - default
+
+    receivers:
+      receiver_creator/diagnostics:
+        watch_observers: [k8s_observer]
+        receivers:
+          pprof/heap:
+            rule: type == "pod" && labels["miggo.io/pprof-port"] != ""
+            resource_attributes:
+              component: '`labels["component"]`'
+            config:
+              remote:
+                endpoint: "http://`endpoint`:`labels[\"miggo.io/pprof-port\"]`/debug/pprof/heap"
+                collection_interval: 10s
+                initial_delay: 10s
+          pprof/profiler-heap:
+            rule: type == "pod" && labels["miggo.io/pprof-profiler-port"] != ""
+            resource_attributes:
+              component: '`labels["component"]`'
+            config:
+              remote:
+                endpoint: "http://`endpoint`:`labels[\"miggo.io/pprof-profiler-port\"]`/debug/pprof/heap"
+                collection_interval: 10s
+                initial_delay: 10s
+
+    processors:
+      resource/diagnostics:
+        attributes:
+          - key: service.name
+            value: "sensor_diagnostic"
+            action: upsert
+          - key: cluster.name
+            value: "my-cluster"
+            action: upsert
+          - key: node.name
+            value: "${env:NODE_NAME}"
+            action: upsert
+          - key: k8s.namespace.name
+            action: delete
+          - key: k8s.pod.name
+            action: delete
+          - key: k8s.pod.uid
+            action: delete
+    
+    exporters:
+      otlp_http/diagnostics:
+        profiles_endpoint: https://collector.miggo.io/v1development/profiles
+        auth:
+          authenticator: oauth2client
+
+    service:
+      pipelines:
+        profiles/diagnostics:
+          receivers:
+            - receiver_creator/diagnostics
+          processors:
+            - resource/diagnostics
+          exporters:
+            - otlp_http/diagnostics
+

--- a/charts/miggo/examples/default/rendered/miggo-collector/diagnostic-pprof-config-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/diagnostic-pprof-config-cm.yaml
@@ -27,7 +27,7 @@ data:
             config:
               remote:
                 endpoint: "http://`endpoint`:`labels[\"miggo.io/pprof-port\"]`/debug/pprof/heap"
-                collection_interval: 10s
+                collection_interval: 1m
                 initial_delay: 10s
           pprof/profiler-heap:
             rule: type == "pod" && labels["miggo.io/pprof-profiler-port"] != ""
@@ -36,7 +36,7 @@ data:
             config:
               remote:
                 endpoint: "http://`endpoint`:`labels[\"miggo.io/pprof-profiler-port\"]`/debug/pprof/heap"
-                collection_interval: 10s
+                collection_interval: 1m
                 initial_delay: 10s
 
     processors:

--- a/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.228
+    helm.sh/chart: miggo-0.0.230
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.706.1"
+    app.kubernetes.io/version: "v26.708.4"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 

--- a/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.227
+    helm.sh/chart: miggo-0.0.228
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.703.1"
+    app.kubernetes.io/version: "v26.706.1"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 

--- a/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.228
+    helm.sh/chart: miggo-0.0.230
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.706.1"
+    app.kubernetes.io/version: "v26.708.4"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,10 +23,10 @@ spec:
         checksum/config: 6ed877707581906ad34573544b36de695bd4e68848d208fc2a19372f691cdd49
       labels:
         component: miggo-runtime
-        helm.sh/chart: miggo-0.0.228
+        helm.sh/chart: miggo-0.0.230
         app.kubernetes.io/name: miggo-runtime
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.706.1"
+        app.kubernetes.io/version: "v26.708.4"
         app.kubernetes.io/managed-by: Helm
         miggo.io/pprof-port: "6050"
         miggo.io/pprof-profiler-port: "6051"
@@ -42,7 +42,7 @@ spec:
         - name: miggo-runtime
           securityContext:
             privileged: true
-          image: "registry.miggo.io/miggo/miggo-runtime:v26.706.1"
+          image: "registry.miggo.io/miggo/miggo-runtime:v26.708.4"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -54,7 +54,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.228
+            - --chart-version=0.0.230
             - --disable-profiler=false
             - --enable-network-tracing=false
             - --enable-file-access-tracing=false
@@ -115,7 +115,7 @@ spec:
           - name: unix-socket
             mountPath: /tmp/grpc
         - name: profiler
-          image: "registry.miggo.io/miggo/miggo-profiler:v26.706.1"
+          image: "registry.miggo.io/miggo/miggo-profiler:v26.708.4"
           imagePullPolicy: IfNotPresent
           command:
             - /root/ebpf-profiler

--- a/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.227
+    helm.sh/chart: miggo-0.0.228
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.703.1"
+    app.kubernetes.io/version: "v26.706.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,11 +23,13 @@ spec:
         checksum/config: 6ed877707581906ad34573544b36de695bd4e68848d208fc2a19372f691cdd49
       labels:
         component: miggo-runtime
-        helm.sh/chart: miggo-0.0.227
+        helm.sh/chart: miggo-0.0.228
         app.kubernetes.io/name: miggo-runtime
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.703.1"
+        app.kubernetes.io/version: "v26.706.1"
         app.kubernetes.io/managed-by: Helm
+        miggo.io/pprof-port: "6050"
+        miggo.io/pprof-profiler-port: "6051"
     spec:
       imagePullSecrets:
         
@@ -40,7 +42,7 @@ spec:
         - name: miggo-runtime
           securityContext:
             privileged: true
-          image: "registry.miggo.io/miggo/miggo-runtime:v26.703.1"
+          image: "registry.miggo.io/miggo/miggo-runtime:v26.706.1"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -52,7 +54,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.227
+            - --chart-version=0.0.228
             - --disable-profiler=false
             - --enable-network-tracing=false
             - --enable-file-access-tracing=false
@@ -60,6 +62,7 @@ spec:
             - --cgroup-registry-sync-interval=1m
             - --cgroup-registry-clean-interval=1h
             - --cgroup-root-dir=/cgroup
+            - --pprof-port=6050
             - --include-system-namespaces=false
             - --denied-namespaces=default
           envFrom:
@@ -112,7 +115,7 @@ spec:
           - name: unix-socket
             mountPath: /tmp/grpc
         - name: profiler
-          image: "registry.miggo.io/miggo/miggo-profiler:v26.703.1"
+          image: "registry.miggo.io/miggo/miggo-profiler:v26.706.1"
           imagePullPolicy: IfNotPresent
           command:
             - /root/ebpf-profiler
@@ -125,6 +128,7 @@ spec:
             - -probabilistic-threshold=100
             - -probabilistic-interval=1m0s
             - -tracers=perl,php,python,hotspot,v8,go
+            - -pprof=0.0.0.0:6051
           env:
             - name: GOMEMLIMIT
               value: "409MiB"

--- a/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-pod-watcher-cr
   labels:
-    helm.sh/chart: miggo-0.0.228
+    helm.sh/chart: miggo-0.0.230
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.706.1"
+    app.kubernetes.io/version: "v26.708.4"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-pod-watcher-cr
   labels:
-    helm.sh/chart: miggo-0.0.227
+    helm.sh/chart: miggo-0.0.228
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.703.1"
+    app.kubernetes.io/version: "v26.706.1"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-pod-watcher-crb
   labels:
-    helm.sh/chart: miggo-0.0.227
+    helm.sh/chart: miggo-0.0.228
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.703.1"
+    app.kubernetes.io/version: "v26.706.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-pod-watcher-crb
   labels:
-    helm.sh/chart: miggo-0.0.228
+    helm.sh/chart: miggo-0.0.230
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.706.1"
+    app.kubernetes.io/version: "v26.708.4"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.227
+    helm.sh/chart: miggo-0.0.228
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.703.1"
+    app.kubernetes.io/version: "v26.706.1"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 

--- a/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.228
+    helm.sh/chart: miggo-0.0.230
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.706.1"
+    app.kubernetes.io/version: "v26.708.4"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 

--- a/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.228
+    helm.sh/chart: miggo-0.0.230
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.706.1"
+    app.kubernetes.io/version: "v26.708.4"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,10 +23,10 @@ spec:
       annotations:
       labels:
         component: miggo-scanner
-        helm.sh/chart: miggo-0.0.228
+        helm.sh/chart: miggo-0.0.230
         app.kubernetes.io/name: miggo-scanner
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.706.1"
+        app.kubernetes.io/version: "v26.708.4"
         app.kubernetes.io/managed-by: Helm
         miggo.io/pprof-port: "6050"
     spec:
@@ -40,7 +40,7 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
-          image: "registry.miggo.io/miggo/miggo-scanner:v26.706.1"
+          image: "registry.miggo.io/miggo/miggo-scanner:v26.708.4"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -52,7 +52,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.228
+            - --chart-version=0.0.230
             - --queue-size=10000
             
             - --cache-flush-interval=168h

--- a/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.227
+    helm.sh/chart: miggo-0.0.228
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.703.1"
+    app.kubernetes.io/version: "v26.706.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,11 +23,12 @@ spec:
       annotations:
       labels:
         component: miggo-scanner
-        helm.sh/chart: miggo-0.0.227
+        helm.sh/chart: miggo-0.0.228
         app.kubernetes.io/name: miggo-scanner
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.703.1"
+        app.kubernetes.io/version: "v26.706.1"
         app.kubernetes.io/managed-by: Helm
+        miggo.io/pprof-port: "6050"
     spec:
       imagePullSecrets:
         
@@ -39,7 +40,7 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
-          image: "registry.miggo.io/miggo/miggo-scanner:v26.703.1"
+          image: "registry.miggo.io/miggo/miggo-scanner:v26.706.1"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -51,7 +52,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.227
+            - --chart-version=0.0.228
             - --queue-size=10000
             
             - --cache-flush-interval=168h
@@ -62,6 +63,7 @@ spec:
             - --cache-cm-namespace=default
             
             
+            - --pprof-port=6050
             - --include-system-namespaces=false
             - --denied-namespaces=default
           envFrom:

--- a/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.228
+    helm.sh/chart: miggo-0.0.230
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.706.1"
+    app.kubernetes.io/version: "v26.708.4"
     app.kubernetes.io/managed-by: Helm
   annotations:
 automountServiceAccountToken: true

--- a/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.227
+    helm.sh/chart: miggo-0.0.228
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.703.1"
+    app.kubernetes.io/version: "v26.706.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 automountServiceAccountToken: true

--- a/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.228
+    helm.sh/chart: miggo-0.0.230
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.706.1"
+    app.kubernetes.io/version: "v26.708.4"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -21,13 +21,13 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/values: 5df3c30be97158b04626a0a557b09671867c3997505b87b86137152db912c0dc
+        checksum/values: e55a36d6b52be835ab27a7d0f7b7ec61ab3b8743bc5ffa1cd0c214333eb9a966
       labels:
         component: miggo-watch
-        helm.sh/chart: miggo-0.0.228
+        helm.sh/chart: miggo-0.0.230
         app.kubernetes.io/name: miggo-watch
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.706.1"
+        app.kubernetes.io/version: "v26.708.4"
         app.kubernetes.io/managed-by: Helm
         miggo.io/pprof-port: "6050"
     spec:
@@ -41,7 +41,7 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
-          image: "registry.miggo.io/miggo/miggo-watch:v26.706.1"
+          image: "registry.miggo.io/miggo/miggo-watch:v26.708.4"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -53,7 +53,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.228
+            - --chart-version=0.0.230
             - --interval=1h
             - --image-tracker-interval=1h
             - --exclude=pod,replica-set

--- a/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.227
+    helm.sh/chart: miggo-0.0.228
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.703.1"
+    app.kubernetes.io/version: "v26.706.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -21,14 +21,15 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/values: 94ee8fdccc9a28b5e5b648851b9519d65f2864311e9980b4d1f40c0aacce34cd
+        checksum/values: 5df3c30be97158b04626a0a557b09671867c3997505b87b86137152db912c0dc
       labels:
         component: miggo-watch
-        helm.sh/chart: miggo-0.0.227
+        helm.sh/chart: miggo-0.0.228
         app.kubernetes.io/name: miggo-watch
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.703.1"
+        app.kubernetes.io/version: "v26.706.1"
         app.kubernetes.io/managed-by: Helm
+        miggo.io/pprof-port: "6050"
     spec:
       imagePullSecrets:
         
@@ -40,7 +41,7 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
-          image: "registry.miggo.io/miggo/miggo-watch:v26.703.1"
+          image: "registry.miggo.io/miggo/miggo-watch:v26.706.1"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -52,11 +53,12 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.227
+            - --chart-version=0.0.228
             - --interval=1h
             - --image-tracker-interval=1h
             - --exclude=pod,replica-set
             
+            - --pprof-port=6050
             - --include-system-namespaces=false
             - --denied-namespaces=default
             - --original-sensor-helm-values=/etc/miggo/values/defaults.yaml

--- a/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.227
+    helm.sh/chart: miggo-0.0.228
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.703.1"
+    app.kubernetes.io/version: "v26.706.1"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 

--- a/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.228
+    helm.sh/chart: miggo-0.0.230
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.706.1"
+    app.kubernetes.io/version: "v26.708.4"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 

--- a/charts/miggo/examples/default/rendered/miggo-watch/values-rendered-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/values-rendered-cm.yaml
@@ -252,11 +252,11 @@ data:
     pprof:
       cpu:
         enabled: false
-        interval: 10s
+        interval: 1m
         period: 10
       memory:
         enabled: true
-        interval: 10s
+        interval: 1m
       port: 6050
       profilerPort: 6051
     priorityClassName: ""

--- a/charts/miggo/examples/default/rendered/miggo-watch/values-rendered-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/values-rendered-cm.yaml
@@ -249,6 +249,16 @@ data:
     podAnnotations: {}
     podLabels: {}
     podSecurityContext: {}
+    pprof:
+      cpu:
+        enabled: false
+        interval: 10s
+        period: 10
+      memory:
+        enabled: true
+        interval: 10s
+      port: 6050
+      profilerPort: 6051
     priorityClassName: ""
     probes:
       failureThreshold: 5

--- a/charts/miggo/templates/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/templates/miggo-collector/collector-config-cm.yaml
@@ -45,10 +45,6 @@ data:
               static_configs:
                 - targets: [ 'localhost:8888' ]
               metric_relabel_configs:
-                - source_labels: [__name__]
-                  regex: 'otelcol_(.*)'
-                  target_label: __name__
-                  replacement: 'miggocol_$1'
                 - target_label: "miggo-name"
                   replacement: "{{ .Values.miggo.clusterName }}"
                 - target_label: "node-name"
@@ -72,8 +68,12 @@ data:
           - {{ include "miggo.namespace" . }}
 
     processors:
-      metricstransform:
+      metrics_transform:
         transforms:
+          - include: 'otelcol_(.*)'
+            match_type: regexp
+            action: update
+            new_name: "miggocol_$1"
           - include: miggocol_process_uptime
             match_type: strict
             new_name: miggo_component_status
@@ -99,22 +99,22 @@ data:
         metric_statements:
         - context: metric
           statements:
-            - set(name, Concat(["miggocol", name], "."))
+            - set(metric.name, Concat(["miggocol", metric.name], "."))
         - context: datapoint
           statements:
-            - merge_maps(attributes, resource.attributes, "insert")
-            - set(attributes["miggo-name"], "{{ .Values.miggo.clusterName }}")
-            - set(attributes["pod.hostname"], attributes["k8s.pod.name"])
-            - delete_key(attributes, "k8s.pod.name")
-            - set(attributes["node.name"], attributes["k8s.node.name"])
-            - delete_key(attributes, "k8s.node.name")
-            - delete_key(attributes, "container.id")
-            - delete_key(attributes, "k8s.pod.uid")
-            - delete_key(attributes, "otel.scope.name")
-            - delete_key(attributes, "otel.scope.version")
-            - delete_key(attributes, "pod.hostname")
-            - delete_key(attributes, "container.image.name")
-            - delete_key(attributes, "container.image.tag")
+            - merge_maps(datapoint.attributes, resource.attributes, "insert")
+            - set(datapoint.attributes["miggo-name"], "{{ .Values.miggo.clusterName }}")
+            - set(datapoint.attributes["pod.hostname"], datapoint.attributes["k8s.pod.name"])
+            - delete_key(datapoint.attributes, "k8s.pod.name")
+            - set(datapoint.attributes["node.name"], datapoint.attributes["k8s.node.name"])
+            - delete_key(datapoint.attributes, "k8s.node.name")
+            - delete_key(datapoint.attributes, "container.id")
+            - delete_key(datapoint.attributes, "k8s.pod.uid")
+            - delete_key(datapoint.attributes, "otel.scope.name")
+            - delete_key(datapoint.attributes, "otel.scope.version")
+            - delete_key(datapoint.attributes, "pod.hostname")
+            - delete_key(datapoint.attributes, "container.image.name")
+            - delete_key(datapoint.attributes, "container.image.tag")
 
       filter/self-logs:
         logs:
@@ -147,7 +147,7 @@ data:
       prometheus:
         endpoint: 0.0.0.0:8889
 
-      otlphttp:
+      otlp_http:
         traces_endpoint: {{ include "collectorUrl" . }}/v1/traces
         metrics_endpoint: {{ include "collectorUrl" . }}/v1/metrics
         logs_endpoint: {{ include "collectorUrl" . }}/v1/logs
@@ -162,7 +162,9 @@ data:
     service:
       telemetry:
         resource:
-          origin: "selflogs"
+          attributes:
+            - name: origin
+              value: "selflogs"
         logs:
           encoding: json
           level: "{{ .Values.miggoCollector.config.internalLogVerbosity }}"
@@ -185,6 +187,9 @@ data:
         - health_check
         - oauth2client
         - k8s_leader_elector
+        {{- if .Values.pprof.port }}
+        - k8s_observer
+        {{- end }}
         {{- range .Values.miggoCollector.extraExtensionNames }}
         - {{ . }}
         {{- end }}
@@ -194,7 +199,7 @@ data:
           receivers:
             - otlp
           exporters:
-            - otlphttp
+            - otlp_http
             {{- range .Values.miggoCollector.extraExporterNames }}
             - {{ . }}
             {{- end }}
@@ -210,7 +215,7 @@ data:
           exporters:
             - debug
             - prometheus
-            - otlphttp
+            - otlp_http
             {{- range .Values.miggoCollector.extraExporterNames }}
             - {{ . }}
             {{- end }}
@@ -219,14 +224,14 @@ data:
             - prometheus
           processors:
             - batch/metrics
-            - metricstransform
+            - metrics_transform
             {{- range .Values.miggoCollector.extraProcessorNames }}
             - {{ . }}
             {{- end }}
           exporters:
             - debug
             - prometheus
-            - otlphttp
+            - otlp_http
             {{- range .Values.miggoCollector.extraExporterNames }}
             - {{ . }}
             {{- end }}
@@ -242,7 +247,7 @@ data:
             {{- end }}
           exporters:
             - prometheus
-            - otlphttp
+            - otlp_http
             {{- range .Values.miggoCollector.extraExporterNames }}
             - {{ . }}
             {{- end }}
@@ -257,7 +262,7 @@ data:
             {{- end }}
           exporters:
             - debug
-            - otlphttp
+            - otlp_http
             {{- range .Values.miggoCollector.extraExporterNames }}
             - {{ . }}
             {{- end }}
@@ -271,7 +276,7 @@ data:
             {{- end }}
           exporters:
             - debug
-            - otlphttp
+            - otlp_http
             {{- range .Values.miggoCollector.extraExporterNames }}
             - {{ . }}
             {{- end }}
@@ -286,7 +291,7 @@ data:
             - {{ . }}
             {{- end }}
           exporters:
-            - otlphttp
+            - otlp_http
             {{- range .Values.miggoCollector.extraExporterNames }}
             - {{ . }}
             {{- end }}

--- a/charts/miggo/templates/miggo-collector/deployment.yaml
+++ b/charts/miggo/templates/miggo-collector/deployment.yaml
@@ -128,7 +128,11 @@ spec:
           args:
             - --config
             - /etc/collector/config.yaml
-            {{- if .Values.miggoRuntime.profiler.enabled }}
+            {{- if .Values.pprof.port }}
+            - --config
+            - /etc/collector/diagnostic-pprof.yaml
+            {{- end }}
+            {{- if or .Values.miggoRuntime.profiler.enabled .Values.pprof.port }}
             - --feature-gates
             - service.profilesSupport
             {{- end }}
@@ -173,6 +177,11 @@ spec:
           volumeMounts:
           - name: collector-config
             mountPath: /etc/collector
+          {{- if .Values.pprof.port }}
+          - name: diagnostic-pprof-config
+            mountPath: /etc/collector/diagnostic-pprof.yaml
+            subPath: diagnostic-pprof.yaml
+          {{- end }}
           {{ if (include "accessKeySecret" .) }}
           - name: access-key
             mountPath: {{ .Values.miggoCollector.accessKeyMountLocation }}
@@ -190,6 +199,11 @@ spec:
       - name: collector-config-cm
         configMap:
           name: collector-config-cm
+      {{- if .Values.pprof.port }}
+      - name: diagnostic-pprof-config
+        configMap:
+          name: diagnostic-pprof-config-cm
+      {{- end }}
       {{ if (include "accessKeySecret" .) }}
       - name: access-key
         secret:

--- a/charts/miggo/templates/miggo-collector/deployment.yaml
+++ b/charts/miggo/templates/miggo-collector/deployment.yaml
@@ -30,6 +30,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/miggo-collector/collector-config-cm.yaml") . | sha256sum }}
+        checksum/diagnostic-config: {{ include (print $.Template.BasePath "/miggo-collector/diagnostic-pprof-config-cm.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}

--- a/charts/miggo/templates/miggo-collector/diagnostic-pprof-config-cm.yaml
+++ b/charts/miggo/templates/miggo-collector/diagnostic-pprof-config-cm.yaml
@@ -1,0 +1,106 @@
+{{- if and .Values.miggoCollector.enabled .Values.pprof.port }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: diagnostic-pprof-config-cm
+  namespace: {{ include "miggo.namespace" . }}
+data:
+  diagnostic-pprof.yaml: |
+    extensions:
+      k8s_observer:
+        auth_type: serviceAccount
+        observe_pods: true
+        observe_nodes: false
+        observe_services: false
+        {{- if .Values.miggoCollector.instancePerNode }}
+        node: "${env:NODE_NAME}"
+        {{- end }}
+        namespaces:
+          - {{ include "miggo.namespace" . }}
+
+    receivers:
+      receiver_creator/diagnostics:
+        watch_observers: [k8s_observer]
+        receivers:
+          {{- if .Values.pprof.memory.enabled }}
+          pprof/heap:
+            rule: type == "pod" && labels["miggo.io/pprof-port"] != ""
+            resource_attributes:
+              component: '`labels["component"]`'
+            config:
+              remote:
+                endpoint: "http://`endpoint`:`labels[\"miggo.io/pprof-port\"]`/debug/pprof/heap"
+                collection_interval: {{ .Values.pprof.memory.interval }}
+                initial_delay: 10s
+          {{- end }}
+          {{- if .Values.pprof.cpu.enabled }}
+          pprof/cpu:
+            rule: type == "pod" && labels["miggo.io/pprof-port"] != ""
+            resource_attributes:
+              component: '`labels["component"]`'
+            config:
+              remote:
+                endpoint: "http://`endpoint`:`labels[\"miggo.io/pprof-port\"]`/debug/pprof/profile?seconds={{ .Values.pprof.cpu.period }}"
+                collection_interval: {{ .Values.pprof.cpu.interval }}
+                initial_delay: 10s
+          {{- end }}
+          {{- if and .Values.miggoRuntime.profiler.enabled .Values.pprof.profilerPort }}
+          {{- if .Values.pprof.memory.enabled }}
+          pprof/profiler-heap:
+            rule: type == "pod" && labels["miggo.io/pprof-profiler-port"] != ""
+            resource_attributes:
+              component: '`labels["component"]`'
+            config:
+              remote:
+                endpoint: "http://`endpoint`:`labels[\"miggo.io/pprof-profiler-port\"]`/debug/pprof/heap"
+                collection_interval: {{ .Values.pprof.memory.interval }}
+                initial_delay: 10s
+          {{- end }}
+          {{- if .Values.pprof.cpu.enabled }}
+          pprof/profiler-cpu:
+            rule: type == "pod" && labels["miggo.io/pprof-profiler-port"] != ""
+            resource_attributes:
+              component: '`labels["component"]`'
+            config:
+              remote:
+                endpoint: "http://`endpoint`:`labels[\"miggo.io/pprof-profiler-port\"]`/debug/pprof/profile?seconds={{ .Values.pprof.cpu.period }}"
+                collection_interval: {{ .Values.pprof.cpu.interval }}
+                initial_delay: 10s
+          {{- end }}
+          {{- end }}
+
+    processors:
+      resource/diagnostics:
+        attributes:
+          - key: service.name
+            value: "sensor_diagnostic"
+            action: upsert
+          - key: cluster.name
+            value: {{ .Values.miggo.clusterName | quote }}
+            action: upsert
+          - key: node.name
+            value: "${env:NODE_NAME}"
+            action: upsert
+          - key: k8s.namespace.name
+            action: delete
+          - key: k8s.pod.name
+            action: delete
+          - key: k8s.pod.uid
+            action: delete
+    
+    exporters:
+      otlp_http/diagnostics:
+        profiles_endpoint: {{ include "collectorUrl" . }}/v1development/profiles
+        auth:
+          authenticator: oauth2client
+
+    service:
+      pipelines:
+        profiles/diagnostics:
+          receivers:
+            - receiver_creator/diagnostics
+          processors:
+            - resource/diagnostics
+          exporters:
+            - otlp_http/diagnostics
+{{- end }}

--- a/charts/miggo/templates/miggo-runtime/daemonset.yaml
+++ b/charts/miggo/templates/miggo-runtime/daemonset.yaml
@@ -38,6 +38,12 @@ spec:
       labels:
         component: miggo-runtime
         {{- include "miggoRuntime.labels" . | nindent 8 }}
+        {{- if .Values.pprof.port }}
+        miggo.io/pprof-port: {{ .Values.pprof.port | quote }}
+        {{- end }}
+        {{- if and .Values.miggoRuntime.profiler.enabled .Values.pprof.profilerPort }}
+        miggo.io/pprof-profiler-port: {{ .Values.pprof.profilerPort | quote }}
+        {{- end }}
         {{- with .Values.podLabels }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
@@ -83,6 +89,7 @@ spec:
             - --cgroup-registry-sync-interval={{ .Values.miggoRuntime.cgroupRegistrySyncInterval }}
             - --cgroup-registry-clean-interval={{ .Values.miggoRuntime.cgroupRegistryCleanInterval }}
             - --cgroup-root-dir=/cgroup
+            - --pprof-port={{ .Values.pprof.port }}
             {{- include "namespace.flags" . | nindent 12 }}
           {{- range $key, $value := .Values.miggoRuntime.extraArgs }}
             {{- if kindIs "invalid" $value }}
@@ -176,6 +183,9 @@ spec:
             - -probabilistic-threshold={{ .Values.miggoRuntime.profiler.probabilisticThreshold }}
             - -probabilistic-interval={{ .Values.miggoRuntime.profiler.probabilisticInterval }}
             - -tracers={{ join "," .Values.miggoRuntime.profiler.enabledTracers }}
+            {{- if .Values.pprof.profilerPort }}
+            - -pprof=0.0.0.0:{{ .Values.pprof.profilerPort }}
+            {{- end }}
           {{- range $key, $value := .Values.miggoRuntime.profiler.extraArgs }}
             {{- if kindIs "invalid" $value }}
             - --{{ $key }}

--- a/charts/miggo/templates/miggo-scanner/deployment.yaml
+++ b/charts/miggo/templates/miggo-scanner/deployment.yaml
@@ -36,6 +36,9 @@ spec:
       labels:
         component: miggo-scanner
         {{- include "miggo-scanner.labels" . | nindent 8 }}
+        {{- if .Values.pprof.port }}
+        miggo.io/pprof-port: {{ .Values.pprof.port | quote }}
+        {{- end }}
         {{- with .Values.podLabels }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
@@ -90,6 +93,7 @@ spec:
             {{ if .Values.miggoScanner.registryCredentials.secretName }}
             - --registry-credentials-path=/etc/registry-credentials/.dockerconfigjson
             {{ end }}
+            - --pprof-port={{ .Values.pprof.port }}
             {{- include "namespace.flags" . | nindent 12 }}
           envFrom:
           {{- with .Values.extraEnvsFrom }}

--- a/charts/miggo/templates/miggo-watch/deployment.yaml
+++ b/charts/miggo/templates/miggo-watch/deployment.yaml
@@ -37,6 +37,9 @@ spec:
       labels:
         component: miggo-watch
         {{- include "miggo-watch.labels" . | nindent 8 }}
+        {{- if .Values.pprof.port }}
+        miggo.io/pprof-port: {{ .Values.pprof.port | quote }}
+        {{- end }}
         {{- with .Values.podLabels }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
@@ -83,6 +86,7 @@ spec:
             {{ if .Values.miggoWatch.config.disableCompression }}
             - --disable-compression
             {{ end }}
+            - --pprof-port={{ .Values.pprof.port }}
             {{- include "namespace.flags" . | nindent 12 }}
             - --original-sensor-helm-values=/etc/miggo/values/defaults.yaml
             - --rendered-sensor-helm-values=/etc/miggo/values/rendered.yaml

--- a/charts/miggo/tests/endpoints/test.yaml
+++ b/charts/miggo/tests/endpoints/test.yaml
@@ -15,13 +15,13 @@ values:
 tests:
   # ---------- Happy path: defaults propagate ----------
 
-  - it: should point collector-config otlphttp exporters at config.collectorUrl default
+  - it: should point collector-config otlp_http exporters at config.collectorUrl default
     template: templates/miggo-collector/collector-config-cm.yaml
     asserts:
       - matchRegex:
           path: data["config-template.yaml"]
           pattern: |
-            .*otlphttp:
+            .*otlp_http:
               +traces_endpoint: https://collector\.miggo\.io/v1/traces
               +metrics_endpoint: https://collector\.miggo\.io/v1/metrics
               +logs_endpoint: https://collector\.miggo\.io/v1/logs
@@ -47,7 +47,7 @@ tests:
       - matchRegex:
           path: data["config-template.yaml"]
           pattern: |
-            .*otlphttp:
+            .*otlp_http:
               +traces_endpoint: https://my-collector\.example\.com/v1/traces
               +metrics_endpoint: https://my-collector\.example\.com/v1/metrics
               +logs_endpoint: https://my-collector\.example\.com/v1/logs
@@ -91,7 +91,7 @@ tests:
       - matchRegex:
           path: data["config-template.yaml"]
           pattern: |
-            .*otlphttp:
+            .*otlp_http:
               +traces_endpoint: https://legacy-upstream\.example\.com/v1/traces.*
 
   - it: new config.collectorUrl should win over legacy output.otlp.otlpEndpoint when both are set
@@ -106,7 +106,7 @@ tests:
       - matchRegex:
           path: data["config-template.yaml"]
           pattern: |
-            .*otlphttp:
+            .*otlp_http:
               +traces_endpoint: https://new\.example\.com/v1/traces.*
       - notMatchRegex:
           path: data["config-template.yaml"]

--- a/charts/miggo/tests/extra-pipelines/test.yaml
+++ b/charts/miggo/tests/extra-pipelines/test.yaml
@@ -98,7 +98,7 @@ tests:
           pattern: "(?s)traces:.*?- batch/traces"
       - matchRegex:
           path: data["config-template.yaml"]
-          pattern: "(?s)traces:.*?- otlphttp"
+          pattern: "(?s)traces:.*?- otlp_http"
       - matchRegex:
           path: data["config-template.yaml"]
           pattern: "(?s)traces:.*?- debug"

--- a/charts/miggo/tests/pprof/test.yaml
+++ b/charts/miggo/tests/pprof/test.yaml
@@ -1,0 +1,224 @@
+suite: pprof diagnostic profiling
+
+release:
+  name: miggo
+  namespace: miggo-space
+
+templates:
+  - templates/miggo-watch/deployment.yaml
+  - templates/miggo-scanner/deployment.yaml
+  - templates/miggo-runtime/daemonset.yaml
+  - templates/miggo-runtime/fluent-bit-cm.yaml
+  - templates/miggo-collector/deployment.yaml
+  - templates/miggo-collector/collector-config-cm.yaml
+  - templates/miggo-collector/diagnostic-pprof-config-cm.yaml
+
+values:
+  - values.yaml
+
+tests:
+  # --- pod labels ---
+
+  - it: should add pprof-port label to watch pod when pprof.port is set
+    template: templates/miggo-watch/deployment.yaml
+    set:
+      pprof.port: 6060
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["miggo.io/pprof-port"]
+          value: "6060"
+
+  - it: should not add pprof-port label to watch pod when pprof.port is 0
+    template: templates/miggo-watch/deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.metadata.labels["miggo.io/pprof-port"]
+
+  - it: should add pprof-port label to scanner pod when pprof.port is set
+    template: templates/miggo-scanner/deployment.yaml
+    set:
+      pprof.port: 6060
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["miggo.io/pprof-port"]
+          value: "6060"
+
+  - it: should add pprof-port label to runtime pod when pprof.port is set
+    template: templates/miggo-runtime/daemonset.yaml
+    set:
+      pprof.port: 6060
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["miggo.io/pprof-port"]
+          value: "6060"
+
+  - it: should add pprof-profiler-port label to runtime pod when profilerPort is set
+    template: templates/miggo-runtime/daemonset.yaml
+    set:
+      pprof.port: 6060
+      pprof.profilerPort: 6061
+      miggoRuntime.profiler.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["miggo.io/pprof-profiler-port"]
+          value: "6061"
+
+  - it: should not add pprof-profiler-port label when profiler is disabled
+    template: templates/miggo-runtime/daemonset.yaml
+    set:
+      pprof.port: 6060
+      pprof.profilerPort: 6061
+    asserts:
+      - notExists:
+          path: spec.template.metadata.labels["miggo.io/pprof-profiler-port"]
+
+  # --- container args ---
+
+  - it: should pass --pprof-port to watch container
+    template: templates/miggo-watch/deployment.yaml
+    set:
+      pprof.port: 6060
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "miggo-watch")].args
+          content: "--pprof-port=6060"
+
+  - it: should pass --pprof-port to scanner container
+    template: templates/miggo-scanner/deployment.yaml
+    set:
+      pprof.port: 6060
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "miggo-scanner")].args
+          content: "--pprof-port=6060"
+
+  - it: should pass --pprof-port to runtime container
+    template: templates/miggo-runtime/daemonset.yaml
+    set:
+      pprof.port: 6060
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "miggo-runtime")].args
+          content: "--pprof-port=6060"
+
+  - it: should pass -pprof arg to profiler sidecar when profilerPort is set
+    template: templates/miggo-runtime/daemonset.yaml
+    set:
+      pprof.port: 6060
+      pprof.profilerPort: 6061
+      miggoRuntime.profiler.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "profiler")].args
+          content: "-pprof=0.0.0.0:6061"
+
+  # --- collector deployment args ---
+
+  - it: should load diagnostic config in collector when pprof.port is set
+    template: templates/miggo-collector/deployment.yaml
+    set:
+      pprof.port: 6060
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "miggo-collector")].args
+          content: "/etc/collector/diagnostic-pprof.yaml"
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "miggo-collector")].args
+          content: "service.profilesSupport"
+
+  - it: should not load diagnostic config in collector when pprof.port is 0
+    template: templates/miggo-collector/deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name == "miggo-collector")].args
+          content: "/etc/collector/diagnostic-pprof.yaml"
+
+  # --- collector main config ---
+
+  - it: should add k8s_observer to collector service extensions when pprof.port is set
+    template: templates/miggo-collector/collector-config-cm.yaml
+    set:
+      pprof.port: 6060
+    asserts:
+      - matchRegex:
+          path: data["config-template.yaml"]
+          pattern: "- k8s_observer"
+
+  - it: should not add k8s_observer to collector service extensions when pprof.port is 0
+    template: templates/miggo-collector/collector-config-cm.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["config-template.yaml"]
+          pattern: "k8s_observer"
+
+  # --- diagnostic ConfigMap ---
+
+  - it: should create diagnostic-pprof ConfigMap when pprof.port is set
+    template: templates/miggo-collector/diagnostic-pprof-config-cm.yaml
+    set:
+      pprof.port: 6060
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["diagnostic-pprof.yaml"]
+          pattern: "receiver_creator/diagnostics"
+      - matchRegex:
+          path: data["diagnostic-pprof.yaml"]
+          pattern: "pprof/cpu"
+      - matchRegex:
+          path: data["diagnostic-pprof.yaml"]
+          pattern: "pprof/heap"
+      - matchRegex:
+          path: data["diagnostic-pprof.yaml"]
+          pattern: "otlp_http/diagnostics"
+
+  - it: should not create diagnostic-pprof ConfigMap when pprof.port is 0
+    template: templates/miggo-collector/diagnostic-pprof-config-cm.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should restrict k8s_observer to local node in DaemonSet mode
+    template: templates/miggo-collector/diagnostic-pprof-config-cm.yaml
+    set:
+      pprof.port: 6060
+      miggoCollector.instancePerNode: true
+    asserts:
+      - matchRegex:
+          path: data["diagnostic-pprof.yaml"]
+          pattern: 'node: "\$\{env:NODE_NAME\}"'
+
+  - it: should not restrict k8s_observer to node in Deployment mode
+    template: templates/miggo-collector/diagnostic-pprof-config-cm.yaml
+    set:
+      pprof.port: 6060
+    asserts:
+      - notMatchRegex:
+          path: data["diagnostic-pprof.yaml"]
+          pattern: "node:"
+
+  - it: should include profiler receivers in diagnostic config when profilerPort is set
+    template: templates/miggo-collector/diagnostic-pprof-config-cm.yaml
+    set:
+      pprof.port: 6060
+      pprof.profilerPort: 6061
+      miggoRuntime.profiler.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["diagnostic-pprof.yaml"]
+          pattern: "pprof/profiler-cpu"
+      - matchRegex:
+          path: data["diagnostic-pprof.yaml"]
+          pattern: "pprof/profiler-heap"
+
+  - it: should not include profiler receivers when profilerPort is 0
+    template: templates/miggo-collector/diagnostic-pprof-config-cm.yaml
+    set:
+      pprof.port: 6060
+    asserts:
+      - notMatchRegex:
+          path: data["diagnostic-pprof.yaml"]
+          pattern: "pprof/profiler"

--- a/charts/miggo/tests/pprof/values.yaml
+++ b/charts/miggo/tests/pprof/values.yaml
@@ -1,5 +1,8 @@
 miggo:
-  clusterName: "simple-test"
+  clusterName: "pprof-test"
+
+config:
+  accessKey: "test-key"
 
 miggoWatch:
   enabled: true
@@ -9,6 +12,8 @@ miggoScanner:
 
 miggoRuntime:
   enabled: true
+  profiler:
+    enabled: false
 
 miggoCollector:
   enabled: true

--- a/charts/miggo/tests/runtime-profiler/test.yaml
+++ b/charts/miggo/tests/runtime-profiler/test.yaml
@@ -34,7 +34,7 @@ tests:
       - matchRegex:
           path: data["config-template.yaml"]
           pattern: |
-            .*otlphttp:
+            .*otlp_http:
               +traces_endpoint: https://collector\.miggo\.io/v1/traces
               +metrics_endpoint: https://collector\.miggo\.io/v1/metrics
               +logs_endpoint: https://collector\.miggo\.io/v1/logs
@@ -44,7 +44,7 @@ tests:
       - matchRegex:
           path: data["config-template.yaml"]
           pattern: |
-            (?s).*pipelines:.*profiles:\s+receivers:\s+-\s+otlp\s+exporters:\s+-\s+otlphttp\s.*
+            (?s).*pipelines:.*profiles:\s+receivers:\s+-\s+otlp\s+exporters:\s+-\s+otlp_http\s.*
 
   - it: should add both miggo-runtime and profiler containers to the DaemonSet spec
     template: templates/miggo-runtime/daemonset.yaml
@@ -74,6 +74,7 @@ tests:
             - --cgroup-registry-sync-interval=1m
             - --cgroup-registry-clean-interval=1h
             - --cgroup-root-dir=/cgroup
+            - --pprof-port=0
             - --include-system-namespaces=false
             - --denied-namespaces=miggo-space
       - equal:

--- a/charts/miggo/tests/runtime-profiler/values.yaml
+++ b/charts/miggo/tests/runtime-profiler/values.yaml
@@ -17,3 +17,7 @@ miggoRuntime:
 
 miggoCollector:
   enabled: true
+
+pprof:
+  port: 0
+  profilerPort: 0

--- a/charts/miggo/values.yaml
+++ b/charts/miggo/values.yaml
@@ -21,6 +21,27 @@ healthcheck:
   # -- Port number for health check endpoints
   port: 6666
 
+pprof:
+  # -- Port to expose pprof HTTP endpoints on for Scanner, Watch, and Runtime. 0 disables pprof entirely.
+  port: 6050
+  # -- Separate pprof port for the Profiler sidecar container, which shares the
+  # Runtime pod's network namespace and therefore cannot reuse pprof.port.
+  # 0 disables profiler pprof.
+  profilerPort: 6051
+  cpu:
+    # -- Enable CPU profile scraping by the Collector's diagnostic pipeline
+    enabled: false
+    # -- Duration of each blocking CPU profile collection in seconds (passed as
+    # ?seconds=N to the pprof HTTP endpoint). Must be an integer.
+    period: 10
+    # -- How often to trigger a CPU profile collection
+    interval: 10s
+  memory:
+    # -- Enable heap profile scraping by the Collector's diagnostic pipeline
+    enabled: true
+    # -- How often to collect a heap snapshot
+    interval: 10s
+
 probes:
   # -- Timeout seconds for liveness and readiness probes across all components
   timeoutSeconds: 10

--- a/charts/miggo/values.yaml
+++ b/charts/miggo/values.yaml
@@ -35,12 +35,12 @@ pprof:
     # ?seconds=N to the pprof HTTP endpoint). Must be an integer.
     period: 10
     # -- How often to trigger a CPU profile collection
-    interval: 10s
+    interval: 1m
   memory:
     # -- Enable heap profile scraping by the Collector's diagnostic pipeline
     enabled: true
     # -- How often to collect a heap snapshot
-    interval: 10s
+    interval: 1m
 
 probes:
   # -- Timeout seconds for liveness and readiness probes across all components


### PR DESCRIPTION
## Description

Add continuous self-profiling for all sensor components

Phase 1 — pprof exposure: all four sensors now expose pprof endpoints on a configurable port via the new pprof.port / pprof.profilerPort values. Pods get a miggo.io/pprof-port label for discovery.

Phase 2 — collector scraping: a new diagnostic OTel pipeline (profiles/diagnostics) in the collector uses [k8s_observer](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/observer/k8sobserver/README.md) + [receiver_creator](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/receivercreator/README.md) to dynamically discover sensor pods by label and [scrape their pprof](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/pprofextension/README.md) endpoints. Profiles are exported to collector.miggo.io under `type=sensor_diagnostic,component=<component>`. In DaemonSet mode the observer is scoped to the local node to avoid duplication.

Also fixes several collector config deprecation warnings (OTTL path prefixes, otlp_http alias, service.telemetry.resource format, metric rename moved from metric_relabel_configs to metrics_transform) - all simple and verified.


## Chart Information

- **Chart Name:** `miggo`

## Type of Change

- [ ] Chart version bump
- [x] Bug fix
- [x] Feature addition
- [ ] Documentation update

## Testing

  - [x] helm lint passes
  - [x] helm template renders successfully
  - [ ] Chart installs/upgrades without issues
  - [ ] Tested on Kubernetes

## Breaking Changes

- [ x] No breaking changes
