### PR TITLE
scanner: use existing ServiceAccount when miggoScanner.serviceAccount…

### DIFF
--- a/charts/miggo/Chart.yaml
+++ b/charts/miggo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: miggo
 description: A Helm chart for Miggo
 type: application
-version: 0.0.224
+version: 0.0.225
 appVersion: "v26.629.1"
 maintainers:
   - name: miggo-io

--- a/charts/miggo/README.md
+++ b/charts/miggo/README.md
@@ -1,6 +1,6 @@
 # Miggo Helm Chart
 
-![Version: 0.0.224](https://img.shields.io/badge/Version-0.0.224-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.629.1](https://img.shields.io/badge/AppVersion-v26.629.1-informational?style=flat-square)
+![Version: 0.0.225](https://img.shields.io/badge/Version-0.0.225-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v26.629.1](https://img.shields.io/badge/AppVersion-v26.629.1-informational?style=flat-square)
 
 This Helm chart deploys Miggo's components, providing comprehensive monitoring, security, and observability capabilities for your Kubernetes clusters.
 
@@ -220,7 +220,8 @@ The following table lists the configurable parameters of the miggo chart and the
 | miggoScanner.resources.limits.memory | string | `"4Gi"` |  |
 | miggoScanner.resources.requests.cpu | string | `"1000m"` |  |
 | miggoScanner.resources.requests.memory | string | `"2Gi"` |  |
-| miggoScanner.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| miggoScanner.serviceAccount.annotations | object | `{}` | Annotations to add to the chart-created ServiceAccount. Ignored when name is set (pre-existing SA). |
+| miggoScanner.serviceAccount.name | string | `""` | Name of a pre-existing ServiceAccount to use. When empty (default), the chart creates its own ServiceAccount. When set, the chart skips creation and uses this name — for when your IaC (e.g. Terraform + IRSA / EKS Pod Identity) owns the ServiceAccount lifecycle. |
 | miggoScanner.useGOMEMLIMIT | bool | `true` | When enabled, the chart will set the GOMEMLIMIT env var to 80% of the configured resources.limits.memory. If no resources.limits.memory are defined then enabling does nothing. It is HIGHLY recommend to enable this setting and set a value for resources.limits.memory. |
 | miggoScanner.volumeMounts | list | `[]` | Additional volume mounts |
 | miggoScanner.volumes | list | `[]` | Additional volumes |

--- a/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
@@ -425,7 +425,7 @@ data:
                 new_value: Miggo Collector
               - action: add_label
                 new_label: chart_version
-                new_value: 0.0.222
+                new_value: 0.0.224
 
       batch/metrics:
         timeout: 10s

--- a/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.222
+    helm.sh/chart: miggo-0.0.224
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.618.6"
+    app.kubernetes.io/version: "v26.629.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,14 +23,14 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2f500154f840691b3184076457edaa233fe5c1bf8e6dff82b125c0cabe4b3fd7
+        checksum/config: d40852b13179dc6e555e4585e0eb98516be30b5c0b915b09b4991905bcc5cbc7
       labels:
         component: collector
         miggo.io/app: example-collector
-        helm.sh/chart: miggo-0.0.222
+        helm.sh/chart: miggo-0.0.224
         app.kubernetes.io/name: miggo-collector
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.618.6"
+        app.kubernetes.io/version: "v26.629.1"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: example-collector
       initContainers:
         - name: collector-init-container
-          image: "registry.miggo.io/miggo/miggo-collector:v26.618.6"
+          image: "registry.miggo.io/miggo/miggo-collector:v26.629.1"
           securityContext:
             runAsGroup: 65532
             runAsNonRoot: true
@@ -75,7 +75,7 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
-          image: "registry.miggo.io/miggo/miggo-collector:v26.618.6"
+          image: "registry.miggo.io/miggo/miggo-collector:v26.629.1"
           imagePullPolicy: IfNotPresent
           args:
             - --config

--- a/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.222
+    helm.sh/chart: miggo-0.0.224
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.618.6"
+    app.kubernetes.io/version: "v26.629.1"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 

--- a/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.222
+    helm.sh/chart: miggo-0.0.224
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.618.6"
+    app.kubernetes.io/version: "v26.629.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,10 +23,10 @@ spec:
         checksum/config: 6ed877707581906ad34573544b36de695bd4e68848d208fc2a19372f691cdd49
       labels:
         component: miggo-runtime
-        helm.sh/chart: miggo-0.0.222
+        helm.sh/chart: miggo-0.0.224
         app.kubernetes.io/name: miggo-runtime
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.618.6"
+        app.kubernetes.io/version: "v26.629.1"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -40,7 +40,7 @@ spec:
         - name: miggo-runtime
           securityContext:
             privileged: true
-          image: "registry.miggo.io/miggo/miggo-runtime:v26.618.6"
+          image: "registry.miggo.io/miggo/miggo-runtime:v26.629.1"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -52,7 +52,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.222
+            - --chart-version=0.0.224
             - --disable-profiler=false
             - --enable-network-tracing=false
             - --enable-file-access-tracing=false
@@ -112,7 +112,7 @@ spec:
           - name: unix-socket
             mountPath: /tmp/grpc
         - name: profiler
-          image: "registry.miggo.io/miggo/miggo-profiler:v26.618.6"
+          image: "registry.miggo.io/miggo/miggo-profiler:v26.629.1"
           imagePullPolicy: IfNotPresent
           command:
             - /root/ebpf-profiler

--- a/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-pod-watcher-cr
   labels:
-    helm.sh/chart: miggo-0.0.222
+    helm.sh/chart: miggo-0.0.224
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.618.6"
+    app.kubernetes.io/version: "v26.629.1"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-pod-watcher-crb
   labels:
-    helm.sh/chart: miggo-0.0.222
+    helm.sh/chart: miggo-0.0.224
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.618.6"
+    app.kubernetes.io/version: "v26.629.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.222
+    helm.sh/chart: miggo-0.0.224
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.618.6"
+    app.kubernetes.io/version: "v26.629.1"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 

--- a/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.222
+    helm.sh/chart: miggo-0.0.224
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.618.6"
+    app.kubernetes.io/version: "v26.629.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,10 +23,10 @@ spec:
       annotations:
       labels:
         component: miggo-scanner
-        helm.sh/chart: miggo-0.0.222
+        helm.sh/chart: miggo-0.0.224
         app.kubernetes.io/name: miggo-scanner
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.618.6"
+        app.kubernetes.io/version: "v26.629.1"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -39,7 +39,7 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
-          image: "registry.miggo.io/miggo/miggo-scanner:v26.618.6"
+          image: "registry.miggo.io/miggo/miggo-scanner:v26.629.1"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -51,11 +51,11 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.222
+            - --chart-version=0.0.224
             - --queue-size=10000
             
             - --cache-flush-interval=168h
-            - --cache-cleanup-interval=1h
+            - --cache-cleanup-interval=15m
             - --cache-size=10000
             
             - --cache-cm-name=example-cache

--- a/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.222
+    helm.sh/chart: miggo-0.0.224
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.618.6"
+    app.kubernetes.io/version: "v26.629.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 automountServiceAccountToken: true

--- a/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.222
+    helm.sh/chart: miggo-0.0.224
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.618.6"
+    app.kubernetes.io/version: "v26.629.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -21,13 +21,13 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/values: 54235a249eb0896296c72d49305bba6aeed0f3807a7de29be338a489baa9d1e8
+        checksum/values: 94ee8fdccc9a28b5e5b648851b9519d65f2864311e9980b4d1f40c0aacce34cd
       labels:
         component: miggo-watch
-        helm.sh/chart: miggo-0.0.222
+        helm.sh/chart: miggo-0.0.224
         app.kubernetes.io/name: miggo-watch
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.618.6"
+        app.kubernetes.io/version: "v26.629.1"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -40,7 +40,7 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
-          image: "registry.miggo.io/miggo/miggo-watch:v26.618.6"
+          image: "registry.miggo.io/miggo/miggo-watch:v26.629.1"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -52,7 +52,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.222
+            - --chart-version=0.0.224
             - --interval=1h
             - --image-tracker-interval=1h
             - --exclude=pod,replica-set

--- a/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.222
+    helm.sh/chart: miggo-0.0.224
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.618.6"
+    app.kubernetes.io/version: "v26.629.1"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 

--- a/charts/miggo/examples/default/rendered/miggo-watch/values-rendered-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/values-rendered-cm.yaml
@@ -168,7 +168,7 @@ data:
       annotations: {}
       config:
         cache:
-          cleanupInterval: 1h
+          cleanupInterval: 15m
           configMap:
             enabled: true
             name: ""
@@ -202,6 +202,7 @@ data:
           memory: 2Gi
       serviceAccount:
         annotations: {}
+        name: ""
       useGOMEMLIMIT: true
       volumeMounts: []
       volumes: []

--- a/charts/miggo/templates/miggo-scanner/_helpers.tpl
+++ b/charts/miggo/templates/miggo-scanner/_helpers.tpl
@@ -21,3 +21,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "miggo-scanner.configMapCacheName" -}}
 {{- default (printf "%s-cache" (include "miggo.fullname" .)) .Values.miggoScanner.config.cache.configMap.name }}
 {{- end }}
+
+{{- define "miggo-scanner.serviceAccountName" -}}
+{{- if .Values.miggoScanner.serviceAccount.name -}}
+{{- .Values.miggoScanner.serviceAccount.name -}}
+{{- else -}}
+{{- include "miggo.serviceAccountName" . }}-scanner
+{{- end -}}
+{{- end }}

--- a/charts/miggo/templates/miggo-scanner/deployment.yaml
+++ b/charts/miggo/templates/miggo-scanner/deployment.yaml
@@ -48,7 +48,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- include "miggoImagePullSecrets" . | nindent 8 }}
-      serviceAccountName: {{ include "miggo.serviceAccountName" . }}-scanner
+      serviceAccountName: {{ include "miggo-scanner.serviceAccountName" . }}
       {{- with (include "miggo.podSecurityContext.nonpriv" .) }}
       securityContext:
         {{- . | nindent 8 }}

--- a/charts/miggo/templates/miggo-scanner/rolebinding.yaml
+++ b/charts/miggo/templates/miggo-scanner/rolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
   name: miggo-scanner-cluster-binding
 subjects:
 - kind: ServiceAccount
-  name: {{ include "miggo.serviceAccountName" . }}-scanner
+  name: {{ include "miggo-scanner.serviceAccountName" . }}
   namespace: {{ include "miggo.namespace" . }}
 roleRef:
   kind: ClusterRole
@@ -21,7 +21,7 @@ metadata:
   namespace: {{ include "miggo.namespace" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "miggo.serviceAccountName" . }}-scanner
+  name: {{ include "miggo-scanner.serviceAccountName" . }}
   namespace: {{ include "miggo.namespace" . }}
 roleRef:
   kind: Role

--- a/charts/miggo/templates/miggo-scanner/serviceaccount.yaml
+++ b/charts/miggo/templates/miggo-scanner/serviceaccount.yaml
@@ -1,8 +1,8 @@
-{{ if .Values.miggoScanner.enabled }}
+{{ if and .Values.miggoScanner.enabled (not .Values.miggoScanner.serviceAccount.name) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "miggo.serviceAccountName" . }}-scanner
+  name: {{ include "miggo-scanner.serviceAccountName" . }}
   namespace: {{ include "miggo.namespace" . }}
   labels:
     {{- include "miggo.labels" . | nindent 4 }}

--- a/charts/miggo/values.yaml
+++ b/charts/miggo/values.yaml
@@ -244,7 +244,13 @@ miggoScanner:
     kubernetes.io/os: linux
 
   serviceAccount:
-    # -- Annotations to add to the service account
+    # -- Name of a pre-existing ServiceAccount to use. When empty (default), the
+    # chart creates its own ServiceAccount. When set, the chart skips creation
+    # and uses this name — for when your IaC (e.g. Terraform + IRSA / EKS Pod
+    # Identity) owns the ServiceAccount lifecycle.
+    name: ""
+    # -- Annotations to add to the chart-created ServiceAccount. Ignored when
+    # name is set (pre-existing SA).
     annotations: {}
 
   image:


### PR DESCRIPTION
## Description

  - Adds `miggoScanner.serviceAccount.name` value: when set, the chart skips creating the
    ServiceAccount and uses the named one instead
  - When empty (default), behaviour is unchanged — chart creates and owns the SA
  - Adds `miggo-scanner.serviceAccountName` helper that all scanner templates now use
    (serviceaccount, rolebinding, deployment)

## Chart Information

- **Chart Name:** `miggo`

## Type of Change

- [x] Chart version bump
- [ ] Bug fix
- [x] Feature addition
- [x] Documentation update

## Testing

- [x] `helm lint` passes
- [x] `helm template` renders successfully
- [x] Chart installs/upgrades without issues
- [x] Tested on Kubernetes

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes (describe below)
