### PR TITLE
Add publish verification to chart release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,3 +81,20 @@ jobs:
           while [ "${body: -1}" = $'\n' ]; do body="${body%$'\n'}"; done
           printf '%s\n\n%s\n' "$body" "$section" | gh release edit "$tag" --notes-file -
           echo "$section" >> "$GITHUB_STEP_SUMMARY"
+      
+      # Verifies the chart version is actually resolvable in the published index.yaml.
+      # deploy-pages can report success without the CDN having the update yet, or fail
+      # in ways that aren't obvious upstream
+      - name: Verify chart is actually published
+        run: |
+          version=$(grep -E '^version:' charts/miggo/Chart.yaml | head -1 | sed -E 's/version:[[:space:]]*//; s/"//g')
+          for i in $(seq 1 20); do
+            if curl -sf https://miggo-io.github.io/miggo-helm-charts/index.yaml | grep "version: ${version}\$"; then
+              echo "Chart version ${version} confirmed live"
+              exit 0
+            fi
+            echo "Not live yet, retrying in 15s..."
+            sleep 15
+          done
+          echo "::error::Chart version ${version} not found in published index.yaml"
+          exit 1

--- a/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/collector-config-cm.yaml
@@ -425,7 +425,7 @@ data:
                 new_value: Miggo Collector
               - action: add_label
                 new_label: chart_version
-                new_value: 0.0.224
+                new_value: 0.0.227
 
       batch/metrics:
         timeout: 10s

--- a/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.224
+    helm.sh/chart: miggo-0.0.227
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.629.1"
+    app.kubernetes.io/version: "v26.703.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,14 +23,14 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d40852b13179dc6e555e4585e0eb98516be30b5c0b915b09b4991905bcc5cbc7
+        checksum/config: bb631bdb0dfa4bde4d5a32c5442b0b3f5fda48d98cb82341fcfe045bc21090c7
       labels:
         component: collector
         miggo.io/app: example-collector
-        helm.sh/chart: miggo-0.0.224
+        helm.sh/chart: miggo-0.0.227
         app.kubernetes.io/name: miggo-collector
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.629.1"
+        app.kubernetes.io/version: "v26.703.1"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: example-collector
       initContainers:
         - name: collector-init-container
-          image: "registry.miggo.io/miggo/miggo-collector:v26.629.1"
+          image: "registry.miggo.io/miggo/miggo-collector:v26.703.1"
           securityContext:
             runAsGroup: 65532
             runAsNonRoot: true
@@ -75,7 +75,7 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
-          image: "registry.miggo.io/miggo/miggo-collector:v26.629.1"
+          image: "registry.miggo.io/miggo/miggo-collector:v26.703.1"
           imagePullPolicy: IfNotPresent
           args:
             - --config

--- a/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-collector
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.224
+    helm.sh/chart: miggo-0.0.227
     app.kubernetes.io/name: miggo-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.629.1"
+    app.kubernetes.io/version: "v26.703.1"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 

--- a/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.224
+    helm.sh/chart: miggo-0.0.227
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.629.1"
+    app.kubernetes.io/version: "v26.703.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,10 +23,10 @@ spec:
         checksum/config: 6ed877707581906ad34573544b36de695bd4e68848d208fc2a19372f691cdd49
       labels:
         component: miggo-runtime
-        helm.sh/chart: miggo-0.0.224
+        helm.sh/chart: miggo-0.0.227
         app.kubernetes.io/name: miggo-runtime
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.629.1"
+        app.kubernetes.io/version: "v26.703.1"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -40,7 +40,7 @@ spec:
         - name: miggo-runtime
           securityContext:
             privileged: true
-          image: "registry.miggo.io/miggo/miggo-runtime:v26.629.1"
+          image: "registry.miggo.io/miggo/miggo-runtime:v26.703.1"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -52,7 +52,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.224
+            - --chart-version=0.0.227
             - --disable-profiler=false
             - --enable-network-tracing=false
             - --enable-file-access-tracing=false
@@ -112,7 +112,7 @@ spec:
           - name: unix-socket
             mountPath: /tmp/grpc
         - name: profiler
-          image: "registry.miggo.io/miggo/miggo-profiler:v26.629.1"
+          image: "registry.miggo.io/miggo/miggo-profiler:v26.703.1"
           imagePullPolicy: IfNotPresent
           command:
             - /root/ebpf-profiler

--- a/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/role.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-pod-watcher-cr
   labels:
-    helm.sh/chart: miggo-0.0.224
+    helm.sh/chart: miggo-0.0.227
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.629.1"
+    app.kubernetes.io/version: "v26.703.1"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/rolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-pod-watcher-crb
   labels:
-    helm.sh/chart: miggo-0.0.224
+    helm.sh/chart: miggo-0.0.227
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.629.1"
+    app.kubernetes.io/version: "v26.703.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-runtime/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-runtime
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.224
+    helm.sh/chart: miggo-0.0.227
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.629.1"
+    app.kubernetes.io/version: "v26.703.1"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 

--- a/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.224
+    helm.sh/chart: miggo-0.0.227
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.629.1"
+    app.kubernetes.io/version: "v26.703.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -23,10 +23,10 @@ spec:
       annotations:
       labels:
         component: miggo-scanner
-        helm.sh/chart: miggo-0.0.224
+        helm.sh/chart: miggo-0.0.227
         app.kubernetes.io/name: miggo-scanner
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.629.1"
+        app.kubernetes.io/version: "v26.703.1"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -39,7 +39,7 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
-          image: "registry.miggo.io/miggo/miggo-scanner:v26.629.1"
+          image: "registry.miggo.io/miggo/miggo-scanner:v26.703.1"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -51,7 +51,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.224
+            - --chart-version=0.0.227
             - --queue-size=10000
             
             - --cache-flush-interval=168h

--- a/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-scanner
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.224
+    helm.sh/chart: miggo-0.0.227
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.629.1"
+    app.kubernetes.io/version: "v26.703.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 automountServiceAccountToken: true

--- a/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.224
+    helm.sh/chart: miggo-0.0.227
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.629.1"
+    app.kubernetes.io/version: "v26.703.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -24,10 +24,10 @@ spec:
         checksum/values: 94ee8fdccc9a28b5e5b648851b9519d65f2864311e9980b4d1f40c0aacce34cd
       labels:
         component: miggo-watch
-        helm.sh/chart: miggo-0.0.224
+        helm.sh/chart: miggo-0.0.227
         app.kubernetes.io/name: miggo-watch
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v26.629.1"
+        app.kubernetes.io/version: "v26.703.1"
         app.kubernetes.io/managed-by: Helm
     spec:
       imagePullSecrets:
@@ -40,7 +40,7 @@ spec:
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
-          image: "registry.miggo.io/miggo/miggo-watch:v26.629.1"
+          image: "registry.miggo.io/miggo/miggo-watch:v26.703.1"
           imagePullPolicy: IfNotPresent
           args:
             - --cluster-name=my-cluster
@@ -52,7 +52,7 @@ spec:
             - --metric-otlp-endpoint=http://miggo-collector.default.svc.cluster.local:4318
             - --metric-tls-skip-verify=false
             - --metric-interval=60s
-            - --chart-version=0.0.224
+            - --chart-version=0.0.227
             - --interval=1h
             - --image-tracker-interval=1h
             - --exclude=pod,replica-set

--- a/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-watch
   namespace: default
   labels:
-    helm.sh/chart: miggo-0.0.224
+    helm.sh/chart: miggo-0.0.227
     app.kubernetes.io/name: miggo
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v26.629.1"
+    app.kubernetes.io/version: "v26.703.1"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 


### PR DESCRIPTION
## Description

`deploy-pages` reported success recently but the new chart version wasn't actually live in index.yaml. This adds a post-release step that polls the published index.yaml for the new version (with retries for CDN lag) and fails the job loudly if it's not there.

## Chart Information

- **Chart Name:** `miggo`

## Type of Change

- [ ] Chart version bump
- [x] Bug fix
- [ ] Feature addition
- [ ] Documentation update

## Testing

- [x] `helm lint` passes
- [ ] `helm template` renders successfully
- [ ] Chart installs/upgrades without issues
- [ ] Tested on Kubernetes

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes (describe below)
