### PR TITLE
Add config.denyReleaseNamespace flag

### DIFF
--- a/charts/miggo/templates/_helpers.tpl
+++ b/charts/miggo/templates/_helpers.tpl
@@ -138,7 +138,10 @@ Namespace configuration flags
 {{- if .Values.config.allowedNamespaces }}
 - --allowed-namespaces={{ join "," .Values.config.allowedNamespaces }}
 {{- end }}
-{{- $denied := prepend (default (list) .Values.config.deniedNamespaces) (include "miggo.namespace" .) }}
+{{- $denied := default (list) .Values.config.deniedNamespaces }}
+{{- if .Values.config.denyReleaseNamespace }}
+{{- $denied = prepend $denied (include "miggo.namespace" .) }}
+{{- end }}
 - --denied-namespaces={{ join "," $denied }}
 {{- end -}}
 

--- a/charts/miggo/values.yaml
+++ b/charts/miggo/values.yaml
@@ -89,6 +89,11 @@ config:
   # Example: ["test", "deprecated"]
   deniedNamespaces:
 
+  # -- When set to true (default), the release namespace is automatically added
+  # to deniedNamespaces. Set to false when the sensor needs to watch its own
+  # namespace (e.g. dual-tenant setups where workloads share the release namespace).
+  denyReleaseNamespace: true
+
   # -- When set to true, includes system namespaces like kube-system etc.
   # When false (default), automatically adds system namespaces to deniedNamespaces
   # It's recommended to keep this false unless you specifically need to operate on system namespaces


### PR DESCRIPTION
## Summary
- Adds `config.denyReleaseNamespace` (default: `true`) to control whether the release namespace is auto-added to `deniedNamespaces`
- Default behavior unchanged — release namespace is still denied by default
- Setting `denyReleaseNamespace: false` allows the sensor to watch its own namespace

## Use case
DemoV2 dual-tenant setup: sensor is deployed in `demo` namespace but needs to watch both `demo` and `miggo-demo` namespaces. Currently the chart always denies the release namespace, so `miggo-watch` and `miggo-runtime` can't observe `demo` ns workloads/ingresses for the second tenant.

This causes services in `demo` ns (gateway-app, frontendproxy) to not be labeled as internet-exposed on the DemoV2 graph, even though they have ingress objects.

## Changes
- `templates/_helpers.tpl`: conditional `prepend` in `namespace.flags` based on new flag
- `values.yaml`: new `config.denyReleaseNamespace` with docs

## Test plan
- [ ] Default behavior unchanged (denyReleaseNamespace: true) — release namespace still denied
- [ ] Setting denyReleaseNamespace: false — release namespace NOT added to denied list
- [ ] Verify miggo-watch/runtime args reflect the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)