### PR TITLE
remove profiles from debug logs

### DIFF
--- a/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         checksum/config: ba7de647f556a29e005e870d928071e8b95b9e5dc3705bc464dea9c252d00d32
         checksum/diagnostic-config: f10018e2f0aedf397986fdf6f108a44f8db53a9cc1ec6aa8865f85d03d5bdef8
-        checksum/heartbeat-debug-config: 70ffd8a0b05b835958cb5f65b590ffe9478b33ba2b31e59d788058e490370e12
+        checksum/heartbeat-debug-config: d72c105d89be1b4ee6569477f8b4a8f7efdf00a2919169c9787d4df141da0d46
       labels:
         component: collector
         miggo.io/app: example-collector

--- a/charts/miggo/examples/default/rendered/miggo-collector/heartbeat-debug-config-cm.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-collector/heartbeat-debug-config-cm.yaml
@@ -1,9 +1,10 @@
-{{- if .Values.miggoCollector.enabled }}
+---
+# Source: miggo/templates/miggo-collector/heartbeat-debug-config-cm.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: heartbeat-debug-config-cm
-  namespace: {{ include "miggo.namespace" . }}
+  namespace: default
 data:
   heartbeat-debug.yaml: |
     processors:
@@ -24,17 +25,17 @@ data:
       # heartbeat volumes, while still bounding worst-case memory if the
       # pipeline is flooded within a single interval.
       batch/heartbeat_logs:
-        timeout: {{ .Values.miggoCollector.config.heartbeatInterval }}
+        timeout: 2m
         send_batch_size: 1000000
         send_batch_max_size: 0
 
       batch/heartbeat_metrics:
-        timeout: {{ .Values.miggoCollector.config.heartbeatInterval }}
+        timeout: 2m
         send_batch_size: 1000000
         send_batch_max_size: 0
 
       batch/heartbeat_traces:
-        timeout: {{ .Values.miggoCollector.config.heartbeatInterval }}
+        timeout: 2m
         send_batch_size: 1000000
         send_batch_max_size: 0
 
@@ -63,4 +64,4 @@ data:
             - batch/heartbeat_traces
           exporters:
             - debug
-{{- end }}
+


### PR DESCRIPTION
## Description

Debug exporter doesn't support profiles - remove it

## Chart Information

- **Chart Name:** `miggo`

## Type of Change

- [ ] Chart version bump
- [ ] Bug fix
- [ ] Feature addition
- [ ] Documentation update

## Testing

- [ ] `helm lint` passes
- [ ] `helm template` renders successfully
- [ ] Chart installs/upgrades without issues
- [ ] Tested on Kubernetes

## Breaking Changes

- [ ] No breaking changes
- [ ] Breaking changes (describe below)
