### PR TITLE
fix(miggo): runtime SA + CRB subject use serviceAccountName, not fullname (DAQ-173)

### DIFF
--- a/charts/miggo/templates/miggo-runtime/rolebinding.yaml
+++ b/charts/miggo/templates/miggo-runtime/rolebinding.yaml
@@ -11,7 +11,7 @@ roleRef:
   name: {{ include "miggo.fullname" . }}-pod-watcher-cr
 subjects:
 - kind: ServiceAccount
-  name: {{ include "miggo.fullname" . }}-runtime
+  name: {{ include "miggo.serviceAccountName" . }}-runtime
   namespace: '{{ include "miggo.namespace" . }}'
 {{- end }}
 
@@ -29,6 +29,6 @@ roleRef:
   name: {{ include "miggo.fullname" . }}-scc-privileged
 subjects:
   - kind: ServiceAccount
-    name: {{ include "miggo.fullname" . }}-runtime
+    name: {{ include "miggo.serviceAccountName" . }}-runtime
     namespace: '{{ include "miggo.namespace" . }}'
 {{- end }}

--- a/charts/miggo/templates/miggo-runtime/serviceaccount.yaml
+++ b/charts/miggo/templates/miggo-runtime/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "miggo.fullname" . }}-runtime
+  name: {{ include "miggo.serviceAccountName" . }}-runtime
   namespace: {{ include "miggo.namespace" . }}
   labels:
     {{- include "miggo.labels" . | nindent 4 }}


### PR DESCRIPTION
Part of DAQ-173 (sensor namespace move on demo-cluster).

## Problem
`miggo-runtime` is inconsistent about how it names its ServiceAccount:

```
serviceaccount.yaml   metadata.name:      {{ include "miggo.fullname" . }}-runtime          # release-based
rolebinding.yaml      subjects[].name:    {{ include "miggo.fullname" . }}-runtime          # release-based (x2)
daemonset.yaml:53     serviceAccountName: {{ include "miggo.serviceAccountName" . }}-runtime # serviceAccount.name-based
```

Every other component (collector/scanner/watch) uses `miggo.serviceAccountName` (= `default fullname .Values.serviceAccount.name`) for both its SA resource and its reference. Runtime uses `fullname` for the SA resource + ClusterRoleBinding subject but `serviceAccountName` for the DaemonSet reference.

When `serviceAccount.name` is set **and differs from the release name** (e.g. release `security-miggo`, `serviceAccount.name: demo-miggo` after moving the sensor to a dedicated namespace), the DaemonSet references `demo-miggo-runtime` but the chart creates `security-miggo-runtime`:

```
FailedCreate: pods "security-miggo-runtime-" is forbidden:
error looking up service account security/demo-miggo-runtime: serviceaccount "demo-miggo-runtime" not found
```

…and the ClusterRoleBinding would bind a nonexistent SA (runtime loses pod-watcher permissions). When `serviceAccount.name` is unset the two coincide, which is why it was invisible until now.

## Fix
Align the runtime SA resource **and** the ClusterRoleBinding subject to `miggo.serviceAccountName` (matching the DaemonSet reference and the other three components). The binding/role **names** stay `fullname`-based (release-unique) — only the subject SA name changes.

## Verification
`helm template security-miggo charts/miggo --namespace security --set serviceAccount.name=demo-miggo --set miggoRuntime.enabled=true`:
- runtime SA, CRB subject, and DaemonSet `serviceAccountName` → all `demo-miggo-runtime` (consistent);
- workload names unchanged (`security-miggo-runtime` DaemonSet);
- scanner unaffected (`demo-miggo-scanner`, `role-arn` annotation intact → IRSA unchanged).

Chart `version` will be auto-bumped by the `bump-version` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)