### PR TITLE
watch, scanner: grant RBAC for argo rollouts (SEN-520)

### DIFF
--- a/charts/miggo/examples/default/rendered/miggo-scanner/role.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-scanner/role.yaml
@@ -23,6 +23,10 @@ rules:
 - apiGroups: ["batch"]
   resources: ["cronjobs", "jobs"]
   verbs: ["get", "list", "watch"]
+
+- apiGroups: ["argoproj.io"]
+  resources: ["rollouts"]
+  verbs: ["get", "list", "watch"]
 ---
 # Source: miggo/templates/miggo-scanner/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/miggo/examples/default/rendered/miggo-watch/role.yaml
+++ b/charts/miggo/examples/default/rendered/miggo-watch/role.yaml
@@ -33,3 +33,7 @@ rules:
   resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
   verbs: ["get", "list", "watch"]
 
+- apiGroups: ["argoproj.io"]
+  resources: ["rollouts"]
+  verbs: ["get", "list", "watch"]
+

--- a/charts/miggo/templates/miggo-scanner/role.yaml
+++ b/charts/miggo/templates/miggo-scanner/role.yaml
@@ -25,6 +25,10 @@ rules:
   resources: ["cronjobs", "jobs"]
   verbs: ["get", "list", "watch"]
 
+- apiGroups: ["argoproj.io"]
+  resources: ["rollouts"]
+  verbs: ["get", "list", "watch"]
+
 {{- if eq .Values.config.platform "gke" }}
 - apiGroups: [""]
   resources: ["serviceaccounts/token"]

--- a/charts/miggo/templates/miggo-watch/role.yaml
+++ b/charts/miggo/templates/miggo-watch/role.yaml
@@ -31,4 +31,8 @@ rules:
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
   verbs: ["get", "list", "watch"]
+
+- apiGroups: ["argoproj.io"]
+  resources: ["rollouts"]
+  verbs: ["get", "list", "watch"]
 {{ end }}

--- a/charts/miggo/tests/argo-rollouts-rbac/test.yaml
+++ b/charts/miggo/tests/argo-rollouts-rbac/test.yaml
@@ -1,0 +1,64 @@
+suite: Argo Rollouts RBAC for miggo-watch and miggo-scanner
+
+release:
+  name: miggo
+  namespace: miggo-space
+
+templates:
+  - templates/miggo-watch/role.yaml
+  - templates/miggo-scanner/role.yaml
+
+values:
+  - values.yaml
+
+tests:
+  - it: watch ClusterRole can list rollouts
+    template: templates/miggo-watch/role.yaml
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: miggo-watch-cluster-role
+      - equal:
+          path: rules[7].apiGroups
+          value: ["argoproj.io"]
+      - equal:
+          path: rules[7].resources
+          value: ["rollouts"]
+      - equal:
+          path: rules[7].verbs
+          value: ["get", "list", "watch"]
+
+  - it: scanner ClusterRole can get rollouts
+    template: templates/miggo-scanner/role.yaml
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: miggo-scanner-cluster-role
+      - equal:
+          path: rules[4].apiGroups
+          value: ["argoproj.io"]
+      - equal:
+          path: rules[4].resources
+          value: ["rollouts"]
+      - equal:
+          path: rules[4].verbs
+          value: ["get", "list", "watch"]
+
+  - it: scanner rollouts rule keeps its index on gke
+    template: templates/miggo-scanner/role.yaml
+    documentIndex: 0
+    set:
+      config.platform: gke
+    asserts:
+      - equal:
+          path: rules[4].resources
+          value: ["rollouts"]
+      - equal:
+          path: rules[5].resources
+          value: ["serviceaccounts/token"]

--- a/charts/miggo/tests/argo-rollouts-rbac/values.yaml
+++ b/charts/miggo/tests/argo-rollouts-rbac/values.yaml
@@ -1,0 +1,11 @@
+miggo:
+  clusterName: "argo-rollouts-rbac-test"
+
+config:
+  accessKey: "d6918ba5-b727-4d51-bae5-31c2a8ba59cb98944bab-d97a-4e3a-9b22-dae633070ba9"
+
+miggoWatch:
+  enabled: true
+
+miggoScanner:
+  enabled: true


### PR DESCRIPTION
Resolves SEN-520.

Follow-up to miggo-io/k8s-integrations#650, which taught miggo-watch and miggo-scanner to treat Argo Rollouts as Deployments — but neither ClusterRole grants `argoproj.io/rollouts`, so both are denied in every namespace:

```
rollouts.argoproj.io is forbidden: User "system:serviceaccount:security:security-miggo-watch"
cannot list resource "rollouts" in API group "argoproj.io" in the namespace "production"
```

The scanner side is the more damaging half. Before #650, a ReplicaSet owned by a Rollout matched no branch in `getPodController`, so the pod fell through to owner `standalone` and its SBOM was still sent, just unattributed. Now the `Rollout` branch exists, `Rollouts.Get` returns Forbidden, `getPodOwner` propagates the error and the pod is dropped — so rollout workloads currently produce no SBOM at all.

The rule is unconditional rather than values-gated: RBAC rules are matched as strings and never validated against discovery, so it is inert on a cluster with no Argo CRD and starts working the moment the CRD appears. A toggle would silently drop coverage for customers who adopt Argo later.

No backfill is needed once this lands — `seenPods.Add` runs only on the scanner's success path so failed pods were never marked seen, the chart upgrade restarts the scanner with a fresh cache and a full pod re-list, and `handleCache` re-sends owner attribution even on an image-cache hit.

## Test plan

- New `tests/argo-rollouts-rbac` suite: both ClusterRoles carry the rule with `get`/`list`/`watch`, and the scanner's rule keeps its index when `config.platform=gke` adds the token rule after it.
- `./run-tests.sh` — 145 tests across 22 suites pass.
- Rendered examples updated for the two roles only. `make generate-examples` under helm v3.19 produces unrelated whitespace churn against the v4.2.0 output committed by CI, so that churn was reverted and the two role hunks applied directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)